### PR TITLE
fix(parsers): missing first item after Any() in lazy enumeration

### DIFF
--- a/SubtitlesParserV2/Formats/Parsers/SrtParser.cs
+++ b/SubtitlesParserV2/Formats/Parsers/SrtParser.cs
@@ -45,8 +45,8 @@ namespace SubtitlesParserV2.Formats.Parsers
 			using StreamReader reader = new StreamReader(srtStream, encoding, true, 1024, true);
 
 			List<SubtitleModel> items = new List<SubtitleModel>();
-			IEnumerable<string> srtSubParts = GetSrtSubTitleParts(reader); // This is a lazy list, not yet into memory
-			if (srtSubParts.Any()) // Ensure at least 1 part was found
+			IEnumerable<string> srtSubParts = GetSrtSubTitleParts(reader).Peekable(out var srtSubPartsAny); // This is a lazy list, not yet into memory
+			if (srtSubPartsAny) // Ensure at least 1 part was found
 			{
 				bool isFirstPart = true;
 				foreach (string part in srtSubParts)

--- a/SubtitlesParserV2/Formats/Parsers/YttXmlParser.cs
+++ b/SubtitlesParserV2/Formats/Parsers/YttXmlParser.cs
@@ -54,7 +54,7 @@ namespace SubtitlesParserV2.Formats.Parsers
 					string durString = node.Attribute("d")?.Value ?? string.Empty;
 					_ = float.TryParse(startString, default, CultureInfo.InvariantCulture, out start);
 					_ = float.TryParse(durString, default, CultureInfo.InvariantCulture, out duration);
-					// Fallback to SRV1 format (In segonds)
+					// Fallback to SRV1 format (In seconds)
 					if (string.IsNullOrEmpty(startString) && string.IsNullOrEmpty(durString)) 
 					{
 						startString = node.Attribute("start")?.Value ?? string.Empty;

--- a/SubtitlesParserV2/Formats/Parsers/YttXmlParser.cs
+++ b/SubtitlesParserV2/Formats/Parsers/YttXmlParser.cs
@@ -36,8 +36,8 @@ namespace SubtitlesParserV2.Formats.Parsers
 			XElement xElement = XElement.Load(xmlStream);
 
 			// Try to get lyrics in SRV3 format (P element)
-			IEnumerable<XElement> nodeList = xElement.Descendants("p");
-			if (!nodeList.Any()) 
+			IEnumerable<XElement> nodeList = xElement.Descendants("p").Peekable(out var nodeListAny);
+			if (!nodeListAny)
 			{
 				// Fallback to SRV2 & SRV1 format (Text element)
 				nodeList = xElement.Descendants("text");

--- a/SubtitlesParserV2/Helpers/EnumerableHelper.cs
+++ b/SubtitlesParserV2/Helpers/EnumerableHelper.cs
@@ -2,21 +2,34 @@
 
 namespace SubtitlesParserV2.Helpers
 {
-	public static class EnumerableHelper
+	internal static class EnumerableHelper
 	{
+		/// <summary>
+		/// Method to verify if your IEnumerable has at least 1 element while not iterating over it.
+		/// </summary>
+		/// <typeparam name="T"></typeparam>
+		/// <param name="source"></param>
+		/// <param name="hasElements">Do the IEnumerable have at least 1 element?</param>
+		/// <returns>IEnumerable</returns>
 		public static IEnumerable<T> Peekable<T>(this IEnumerable<T> source, out bool hasElements)
 		{
-			var enumerator = source.GetEnumerator();
+			IEnumerator<T> enumerator = source.GetEnumerator();
+			// Try to iterate over the first element
 			hasElements = enumerator.MoveNext();
+			// Return our Enumerator implementation 
 			return Impl(enumerator, hasElements);
 
+			// Handle returning the first iterated element and iterating the next elements of the collection
+			// Need to be a local method as our parent method have a OUT argument, which is not compatible with yield returns
 			static IEnumerable<T> Impl(IEnumerator<T> enumerator, bool hasElements)
 			{
 				using (enumerator)
 				{
 					if (hasElements)
 					{
+						// First iterated element
 						yield return enumerator.Current;
+						// Iterate next elements until end of collection
 						while (enumerator.MoveNext())
 						{
 							yield return enumerator.Current;

--- a/SubtitlesParserV2/Helpers/EnumerableHelper.cs
+++ b/SubtitlesParserV2/Helpers/EnumerableHelper.cs
@@ -1,0 +1,29 @@
+﻿using System.Collections.Generic;
+
+namespace SubtitlesParserV2.Helpers
+{
+	public static class EnumerableHelper
+	{
+		public static IEnumerable<T> Peekable<T>(this IEnumerable<T> source, out bool hasElements)
+		{
+			var enumerator = source.GetEnumerator();
+			hasElements = enumerator.MoveNext();
+			return Impl(enumerator, hasElements);
+
+			static IEnumerable<T> Impl(IEnumerator<T> enumerator, bool hasElements)
+			{
+				using (enumerator)
+				{
+					if (hasElements)
+					{
+						yield return enumerator.Current;
+						while (enumerator.MoveNext())
+						{
+							yield return enumerator.Current;
+						}
+					}
+				}
+			}
+		}
+	}
+}

--- a/SubtitlesParserV2/Helpers/EnumerableHelper.cs
+++ b/SubtitlesParserV2/Helpers/EnumerableHelper.cs
@@ -7,7 +7,7 @@ namespace SubtitlesParserV2.Helpers
 		/// <summary>
 		/// Method to verify if your IEnumerable has at least 1 element while not iterating over it.
 		/// </summary>
-		/// <typeparam name="T"></typeparam>
+		/// <typeparam name="T">The type of the IEnumerable collection</typeparam>
 		/// <param name="source"></param>
 		/// <param name="hasElements">Do the IEnumerable have at least 1 element?</param>
 		/// <returns>IEnumerable</returns>


### PR DESCRIPTION
The first line of subtitles was consumed by the Any method, resulting in it being missing from the parsed data.