### PR TITLE
fix(yttParser): Reduced memory usage

### DIFF
--- a/SubtitlesParserV2/Formats/Parsers/YttXmlParser.cs
+++ b/SubtitlesParserV2/Formats/Parsers/YttXmlParser.cs
@@ -2,13 +2,10 @@
 using System.Collections.Generic;
 using System.Globalization;
 using System.IO;
-using System.Linq;
 using System.Net;
 using System.Text;
-using System.Xml.Linq;
-using Microsoft.Extensions.Logging;
+using System.Xml;
 using SubtitlesParserV2.Helpers;
-using SubtitlesParserV2.Logger;
 using SubtitlesParserV2.Models;
 
 namespace SubtitlesParserV2.Formats.Parsers
@@ -21,64 +18,57 @@ namespace SubtitlesParserV2.Formats.Parsers
 	/// -->
 	internal class YttXmlParser : ISubtitlesParser
 	{
-		private static readonly Type CurrentType = typeof(YttXmlParser);
-		// Alternative for static class, create a logger with the full namespace name
-		private static readonly ILogger _logger = LoggerManager.GetLogger(CurrentType.FullName ?? CurrentType.Name);
-
 		public List<SubtitleModel> ParseStream(Stream xmlStream, Encoding encoding)
 		{
 			StreamHelper.ThrowIfStreamIsNotSeekableOrReadable(xmlStream);
 			// seek the beginning of the stream
 			xmlStream.Position = 0;
+
 			List<SubtitleModel> items = new List<SubtitleModel>();
+			// Read the xml stream line by line
+			using XmlReader reader = XmlReader.Create(xmlStream, new XmlReaderSettings() { IgnoreWhitespace = true, IgnoreComments = true });
 
-			// parse xml stream
-			XElement xElement = XElement.Load(xmlStream);
-
-			// Try to get lyrics in SRV3 format (P element)
-			IEnumerable<XElement> nodeList = xElement.Descendants("p").Peekable(out var nodeListAny);
-			if (!nodeListAny)
+			while (reader.Read()) 
 			{
-				// Fallback to SRV2 & SRV1 format (Text element)
-				nodeList = xElement.Descendants("text");
-			}
-
-			foreach (XElement node in nodeList)
-			{
-				try
+				// Search for subtitle elements (p for SRV3 and text for SRV1/SRV2)
+				if (reader.NodeType == XmlNodeType.Element && (reader.Name == "p" || reader.Name == "text"))
 				{
 					float start;
-					float duration;
+					float duration = 0; // Default duration if parsing fails.
+
 					// Try to get the start & end time for SRV3 & SRV2 format (already in MS)
-					string startString = node.Attribute("t")?.Value ?? string.Empty;
-					string durString = node.Attribute("d")?.Value ?? string.Empty;
-					_ = float.TryParse(startString, default, CultureInfo.InvariantCulture, out start);
-					_ = float.TryParse(durString, default, CultureInfo.InvariantCulture, out duration);
-					// Fallback to SRV1 format (In seconds)
-					if (string.IsNullOrEmpty(startString) && string.IsNullOrEmpty(durString)) 
+					string startString = reader.GetAttribute("t") ?? string.Empty;
+					string durString = reader.GetAttribute("d") ?? string.Empty;
+					// Fallback to SRV1 format if parsing fail (In seconds)
+					if (!float.TryParse(startString, NumberStyles.Float, CultureInfo.InvariantCulture, out start) && !float.TryParse(durString, NumberStyles.Float, CultureInfo.InvariantCulture, out duration))
 					{
-						startString = node.Attribute("start")?.Value ?? string.Empty;
-						durString = node.Attribute("dur")?.Value ?? string.Empty;
-						_ = float.TryParse(startString, NumberStyles.Float, CultureInfo.InvariantCulture, out start);
-						_ = float.TryParse(durString, NumberStyles.Float, CultureInfo.InvariantCulture, out duration);
-						start = start * 1000; // Convert S to MS
-						duration = duration * 1000; // Convert duration S to MS.
+						startString = reader.GetAttribute("start") ?? string.Empty;
+						durString = reader.GetAttribute("dur") ?? string.Empty;
+						if (float.TryParse(startString, NumberStyles.Float, CultureInfo.InvariantCulture, out start)) 
+						{
+							start = start * 1000; // Convert S to MS
+						} else start = -1; // Could not find start time, default "invalid" value is -1
+
+						if (float.TryParse(durString, NumberStyles.Float, CultureInfo.InvariantCulture, out duration)) 
+						{
+							duration = duration * 1000; // Convert duration S to MS.
+						}
 					}
 
-					// Get the text and html decode it as some versions (SRV1 & SRV2) uses html encoding
-					// for certains characters ( ' > &#39;t). Before and after text spaces are also removed.
-					string text = WebUtility.HtmlDecode(node.Value).Trim();
-
-					items.Add(new SubtitleModel()
+					// We need to read the next node to get the text value.
+					if (reader.Read() && reader.NodeType == XmlNodeType.Text) 
 					{
-						StartTime = (int)start,
-						EndTime = (int)(start + duration), // Calculate the "end" time with the duration of the subtitle.
-						Lines = new List<string>() { text }
-					});
-				}
-				catch (Exception ex)
-				{
-					_logger.LogDebug(ex, "Exception raised when parsing xml node {node}: {ex}", node, ex.Message);
+						// Get the text and html decode it as some versions (SRV1 & SRV2) uses html encoding
+						// for certains characters ( ' > &#39;t). Before and after text spaces are also removed.
+						string text = WebUtility.HtmlDecode(reader.Value.Trim());
+
+						items.Add(new SubtitleModel()
+						{
+							StartTime = (int)start,
+							EndTime = (int)(start + duration), // Calculate the "end" time with the duration of the subtitle.
+							Lines = new List<string>() { text }
+						});
+					}
 				}
 			}
 


### PR DESCRIPTION
Now using XmlReader to read the stream line per lines insead of making a copy of the whole stream into memory with XElement.