### PR TITLE
fix(ttmlParser): Reduced memory usage

### DIFF
--- a/SubtitlesParserV2/Formats/Parsers/YttXmlParser.cs
+++ b/SubtitlesParserV2/Formats/Parsers/YttXmlParser.cs
@@ -55,12 +55,12 @@ namespace SubtitlesParserV2.Formats.Parsers
 						}
 					}
 
-					// We need to read the next node to get the text value.
-					if (reader.Read() && reader.NodeType == XmlNodeType.Text) 
+					string text = ParserHelper.XmlReadCurrentElementInnerText(reader);
+					if (text != null) 
 					{
 						// Get the text and html decode it as some versions (SRV1 & SRV2) uses html encoding
-						// for certains characters ( ' > &#39;t). Before and after text spaces are also removed.
-						string text = WebUtility.HtmlDecode(reader.Value.Trim());
+						// for certains characters ( ' > &#39;t).
+						text = WebUtility.HtmlDecode(text);
 
 						items.Add(new SubtitleModel()
 						{

--- a/SubtitlesParserV2/Helpers/ParserHelper.cs
+++ b/SubtitlesParserV2/Helpers/ParserHelper.cs
@@ -1,8 +1,13 @@
 ﻿using System;
+using System.Text;
+using System.Xml;
 
 namespace SubtitlesParserV2.Helpers
 {
-    internal static class ParserHelper
+	/// <summary>
+	/// This class contains helper methods for parsing subtitles.
+	/// </summary>
+	internal static class ParserHelper
     {
 		/// <summary>
 		/// Takes an string, prase it as a <see cref="TimeSpan"/> timecode and turn it into milliseconds.
@@ -24,6 +29,44 @@ namespace SubtitlesParserV2.Helpers
 			{
 				return -1;
 			}
+		}
+
+		/// <summary>
+		/// Takes an xml reader and reads the inner elements (childs) to get all of the text values.
+		/// All texte will be appended together without adding or removing spaces, the final returned result is trimmed.
+		/// </summary>
+		/// <remarks>
+		/// <strong>Will only read child elements with localnames : span,font,string,b,u,i</strong>
+		/// </remarks>
+		/// <param name="reader">The xml reader</param>
+		/// <returns>All child elements text appended together and trimmed</returns>
+		internal static string XmlReadCurrentElementInnerText(XmlReader reader)
+		{
+			StringBuilder textBuilder = new StringBuilder();
+
+			// Ensure our current element has at least one child
+			if (!reader.IsEmptyElement)
+			{
+				// Store the informations of your current element to know when we reach the end of it
+				string rootElementName = reader.LocalName;
+				int rootElementDepth = reader.Depth;
+				while (reader.Read())
+				{
+					if (reader.NodeType == XmlNodeType.Text)
+					{
+						textBuilder.Append(reader.Value);
+					}
+					else if (reader.NodeType == XmlNodeType.Element && (reader.LocalName == "span" || reader.LocalName == "font" || reader.LocalName == "b" || reader.LocalName == "u" || reader.LocalName == "i" || reader.LocalName == "string"))
+					{
+						// Read the content of (<span> / other name) and it's childs
+						textBuilder.Append(XmlReadCurrentElementInnerText(reader));
+					}
+					// If we reach the end of the current element (no more childs), we stop reading
+					else if (reader.NodeType == XmlNodeType.EndElement && reader.LocalName == rootElementName && rootElementDepth == reader.Depth) break;
+				}
+			}
+
+			return textBuilder.ToString().Trim();
 		}
 	}
 }


### PR DESCRIPTION
Now using XmlReader to read the stream line per lines insead of making a copy of the whole stream into memory with XElement.

Added new internal method to read child text elements of XmlReader. This method is now used by `TTML` and `YTT` parser.