### PR TITLE
Add Streaming (with Enumerable) and Async processing. Also standardize the parsing pipeline across parsers.

### DIFF
--- a/SubtitlesParserV2.Tests/SubtitlesParserV2.Tests.csproj
+++ b/SubtitlesParserV2.Tests/SubtitlesParserV2.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net8.0;netstandard2.1</TargetFrameworks>
+    <TargetFrameworks>net8.0;netstandard2.1;net9.0</TargetFrameworks>
     <IsPackable>false</IsPackable>
   </PropertyGroup>
 

--- a/SubtitlesParserV2.Tests/TestFilesManager.cs
+++ b/SubtitlesParserV2.Tests/TestFilesManager.cs
@@ -10,7 +10,7 @@ namespace SubtitlesParserV2.Tests
         {
 			// Get test files from the TestLibrary project
             // from debug/release folder to project root > test library
-			TestFilesPath = GetFiles(@"..\..\..\..\TestLibrary\Content\TestFiles");
+			TestFilesPath = GetFiles(Path.GetFullPath(string.Join(Path.DirectorySeparatorChar,"..","..", "..","..", "TestLibrary", "Content", "TestFiles")));
         }
 
         private static string[] GetFiles(string relativePath) => Directory.GetFiles(Path.GetFullPath(relativePath));

--- a/SubtitlesParserV2.Tests/Test_Parsers.cs
+++ b/SubtitlesParserV2.Tests/Test_Parsers.cs
@@ -4,6 +4,7 @@ using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Text;
+using System.Threading.Tasks;
 using Xunit;
 
 namespace SubtitlesParserV2.Tests
@@ -51,11 +52,12 @@ namespace SubtitlesParserV2.Tests
 		// --------------------------------------------------------------------------------------------------------------------------
 
 		[Fact]
-        private void Parse_SubRip()
+        private async Task Parse_SubRip()
         {
 			SubtitleFormatType targetFormatType = SubtitleFormatType.SubRip;
 
             Dictionary<string, int> invalidTimestamps = new Dictionary<string, int>();
+            Dictionary<string, int> invalidTimestampsAsync = new Dictionary<string, int>();
 			foreach (string filePath in GetFilesRelatedToParser(targetFormatType))
             {
 				using FileStream fileStream = new FileStream(filePath, FileMode.Open, FileAccess.Read);
@@ -63,17 +65,24 @@ namespace SubtitlesParserV2.Tests
 
                 // Verify for timestamp
                 invalidTimestamps.Add(filePath, CountInvalidTimestamps(parsingResult.Subtitles));
+
+				// Test async version
+				fileStream.Position = 0;
+				SubtitleParserResultModel parsingResultAsync = await SubtitleParser.ParseStreamAsync(fileStream, Encoding.UTF8, targetFormatType);
+				invalidTimestampsAsync.Add(filePath, CountInvalidTimestamps(parsingResultAsync.Subtitles));
 			}
             // Verify that every timestamp is valid
             Assert.All(invalidTimestamps, entry => Assert.Equal(0, entry.Value));
+            Assert.All(invalidTimestampsAsync, entry => Assert.Equal(0, entry.Value));
 		}
 
 		[Fact]
-		private void  Parse_LRC()
+		private async Task Parse_LRC()
 		{
 			SubtitleFormatType targetFormatType = SubtitleFormatType.LRC;
 
 			Dictionary<string, int> invalidTimestamps = new Dictionary<string, int>();
+			Dictionary<string, int> invalidTimestampsAsync = new Dictionary<string, int>();
 			foreach (string filePath in GetFilesRelatedToParser(targetFormatType))
 			{
 				using FileStream fileStream = new FileStream(filePath, FileMode.Open, FileAccess.Read);
@@ -82,17 +91,24 @@ namespace SubtitlesParserV2.Tests
 				// Verify for timestamp
 				// NOTE: LRC last subtitle does not have a valid timestamp as per by file format
 				invalidTimestamps.Add(filePath, CountInvalidTimestamps(parsingResult.Subtitles, false, false, true));
+
+				// Test async version
+				fileStream.Position = 0;
+				SubtitleParserResultModel parsingResultAsync = await SubtitleParser.ParseStreamAsync(fileStream, Encoding.UTF8, targetFormatType);
+				invalidTimestampsAsync.Add(filePath, CountInvalidTimestamps(parsingResultAsync.Subtitles, false, false, true));
 			}
 			// Verify that every timestamp is valid
 			Assert.All(invalidTimestamps, entry => Assert.Equal(0, entry.Value));
+			Assert.All(invalidTimestampsAsync, entry => Assert.Equal(0, entry.Value));
 		}
 
 		[Fact]
-		private void Parse_TMPlayer()
+		private async Task Parse_TMPlayer()
 		{
 			SubtitleFormatType targetFormatType = SubtitleFormatType.TMPlayer;
 
 			Dictionary<string, int> invalidTimestamps = new Dictionary<string, int>();
+			Dictionary<string, int> invalidTimestampsAsync = new Dictionary<string, int>();
 			foreach (string filePath in GetFilesRelatedToParser(targetFormatType))
 			{
 				using FileStream fileStream = new FileStream(filePath, FileMode.Open, FileAccess.Read);
@@ -101,17 +117,24 @@ namespace SubtitlesParserV2.Tests
 				// Verify for timestamp
 				// NOTE: TMPlayer last subtitle does not have a valid timestamp as per by file format
 				invalidTimestamps.Add(filePath, CountInvalidTimestamps(parsingResult.Subtitles, false, false, true));
+
+				// Test async version
+				fileStream.Position = 0;
+				SubtitleParserResultModel parsingResultAsync = await SubtitleParser.ParseStreamAsync(fileStream, Encoding.UTF8, targetFormatType);
+				invalidTimestampsAsync.Add(filePath, CountInvalidTimestamps(parsingResultAsync.Subtitles, false, false, true));
 			}
 			// Verify that every timestamp is valid
 			Assert.All(invalidTimestamps, entry => Assert.Equal(0, entry.Value));
+			Assert.All(invalidTimestampsAsync, entry => Assert.Equal(0, entry.Value));
 		}
 
 		[Fact]
-		private void Parse_MicroDvd()
+		private async Task Parse_MicroDvd()
 		{
 			SubtitleFormatType targetFormatType = SubtitleFormatType.MicroDvd;
 
 			Dictionary<string, int> invalidTimestamps = new Dictionary<string, int>();
+			Dictionary<string, int> invalidTimestampsAsync = new Dictionary<string, int>();
 			foreach (string filePath in GetFilesRelatedToParser(targetFormatType))
 			{
 				using FileStream fileStream = new FileStream(filePath, FileMode.Open, FileAccess.Read);
@@ -119,17 +142,24 @@ namespace SubtitlesParserV2.Tests
 
 				// Verify for timestamp
 				invalidTimestamps.Add(filePath, CountInvalidTimestamps(parsingResult.Subtitles));
+
+				// Test async version
+				fileStream.Position = 0;
+				SubtitleParserResultModel parsingResultAsync = await SubtitleParser.ParseStreamAsync(fileStream, Encoding.UTF8, targetFormatType);
+				invalidTimestampsAsync.Add(filePath, CountInvalidTimestamps(parsingResultAsync.Subtitles));
 			}
 			// Verify that every timestamp is valid
 			Assert.All(invalidTimestamps, entry => Assert.Equal(0, entry.Value));
+			Assert.All(invalidTimestampsAsync, entry => Assert.Equal(0, entry.Value));
 		}
 
 		[Fact]
-		private void Parse_SubViewer()
+		private async Task Parse_SubViewer()
 		{
 			SubtitleFormatType targetFormatType = SubtitleFormatType.SubViewer;
 
 			Dictionary<string, int> invalidTimestamps = new Dictionary<string, int>();
+			Dictionary<string, int> invalidTimestampsAsync = new Dictionary<string, int>();
 			foreach (string filePath in GetFilesRelatedToParser(targetFormatType))
 			{
 				using FileStream fileStream = new FileStream(filePath, FileMode.Open, FileAccess.Read);
@@ -137,17 +167,24 @@ namespace SubtitlesParserV2.Tests
 
 				// Verify for timestamp
 				invalidTimestamps.Add(filePath, CountInvalidTimestamps(parsingResult.Subtitles));
+
+				// Test async version
+				fileStream.Position = 0;
+				SubtitleParserResultModel parsingResultAsync = await SubtitleParser.ParseStreamAsync(fileStream, Encoding.UTF8, targetFormatType);
+				invalidTimestampsAsync.Add(filePath, CountInvalidTimestamps(parsingResultAsync.Subtitles));
 			}
 			// Verify that every timestamp is valid
 			Assert.All(invalidTimestamps, entry => Assert.Equal(0, entry.Value));
+			Assert.All(invalidTimestampsAsync, entry => Assert.Equal(0, entry.Value));
 		}
 
 		[Fact]
-		private void Parse_SubStationAlpha()
+		private async Task Parse_SubStationAlpha()
 		{
 			SubtitleFormatType targetFormatType = SubtitleFormatType.SubStationAlpha;
 
 			Dictionary<string, int> invalidTimestamps = new Dictionary<string, int>();
+			Dictionary<string, int> invalidTimestampsAsync = new Dictionary<string, int>();
 			foreach (string filePath in GetFilesRelatedToParser(targetFormatType))
 			{
 				using FileStream fileStream = new FileStream(filePath, FileMode.Open, FileAccess.Read);
@@ -155,17 +192,24 @@ namespace SubtitlesParserV2.Tests
 
 				// Verify for timestamp
 				invalidTimestamps.Add(filePath, CountInvalidTimestamps(parsingResult.Subtitles));
+
+				// Test async version
+				fileStream.Position = 0;
+				SubtitleParserResultModel parsingResultAsync = await SubtitleParser.ParseStreamAsync(fileStream, Encoding.UTF8, targetFormatType);
+				invalidTimestampsAsync.Add(filePath, CountInvalidTimestamps(parsingResultAsync.Subtitles));
 			}
 			// Verify that every timestamp is valid
 			Assert.All(invalidTimestamps, entry => Assert.Equal(0, entry.Value));
+			Assert.All(invalidTimestampsAsync, entry => Assert.Equal(0, entry.Value));
 		}
 
 		[Fact]
-		private void Parse_TTML()
+		private async Task Parse_TTML()
 		{
 			SubtitleFormatType targetFormatType = SubtitleFormatType.TTML;
 
 			Dictionary<string, int> invalidTimestamps = new Dictionary<string, int>();
+			Dictionary<string, int> invalidTimestampsAsync = new Dictionary<string, int>();
 			foreach (string filePath in GetFilesRelatedToParser(targetFormatType))
 			{
 				using FileStream fileStream = new FileStream(filePath, FileMode.Open, FileAccess.Read);
@@ -173,17 +217,24 @@ namespace SubtitlesParserV2.Tests
 
 				// Verify for timestamp
 				invalidTimestamps.Add(filePath, CountInvalidTimestamps(parsingResult.Subtitles));
+
+				// Test async version
+				fileStream.Position = 0;
+				SubtitleParserResultModel parsingResultAsync = await SubtitleParser.ParseStreamAsync(fileStream, Encoding.UTF8, targetFormatType);
+				invalidTimestampsAsync.Add(filePath, CountInvalidTimestamps(parsingResultAsync.Subtitles));
 			}
 			// Verify that every timestamp is valid
 			Assert.All(invalidTimestamps, entry => Assert.Equal(0, entry.Value));
+			Assert.All(invalidTimestampsAsync, entry => Assert.Equal(0, entry.Value));
 		}
 
 		[Fact]
-		private void Parse_WebVTT()
+		private async Task Parse_WebVTT()
 		{
 			SubtitleFormatType targetFormatType = SubtitleFormatType.WebVTT;
 
 			Dictionary<string, int> invalidTimestamps = new Dictionary<string, int>();
+			Dictionary<string, int> invalidTimestampsAsync = new Dictionary<string, int>();
 			foreach (string filePath in GetFilesRelatedToParser(targetFormatType))
 			{
 				using FileStream fileStream = new FileStream(filePath, FileMode.Open, FileAccess.Read);
@@ -191,17 +242,24 @@ namespace SubtitlesParserV2.Tests
 
 				// Verify for timestamp
 				invalidTimestamps.Add(filePath, CountInvalidTimestamps(parsingResult.Subtitles));
+
+				// Test async version
+				fileStream.Position = 0;
+				SubtitleParserResultModel parsingResultAsync = await SubtitleParser.ParseStreamAsync(fileStream, Encoding.UTF8, targetFormatType);
+				invalidTimestampsAsync.Add(filePath, CountInvalidTimestamps(parsingResultAsync.Subtitles));
 			}
 			// Verify that every timestamp is valid
 			Assert.All(invalidTimestamps, entry => Assert.Equal(0, entry.Value));
+			Assert.All(invalidTimestampsAsync, entry => Assert.Equal(0, entry.Value));
 		}
 
 		[Fact]
-		private void Parse_SAMI()
+		private async Task Parse_SAMI()
 		{
 			SubtitleFormatType targetFormatType = SubtitleFormatType.SAMI;
 
 			Dictionary<string, int> invalidTimestamps = new Dictionary<string, int>();
+			Dictionary<string, int> invalidTimestampsAsync = new Dictionary<string, int>();
 			foreach (string filePath in GetFilesRelatedToParser(targetFormatType))
 			{
 				using FileStream fileStream = new FileStream(filePath, FileMode.Open, FileAccess.Read);
@@ -210,17 +268,24 @@ namespace SubtitlesParserV2.Tests
 				// Verify for timestamp
 				// NOTE: SAMI last subtitle does not have a valid timestamp as per by file format
 				invalidTimestamps.Add(filePath, CountInvalidTimestamps(parsingResult.Subtitles, false, false, true));
+
+				// Test async version
+				fileStream.Position = 0;
+				SubtitleParserResultModel parsingResultAsync = await SubtitleParser.ParseStreamAsync(fileStream, Encoding.UTF8, targetFormatType);
+				invalidTimestampsAsync.Add(filePath, CountInvalidTimestamps(parsingResultAsync.Subtitles, false, false, true));
 			}
 			// Verify that every timestamp is valid
 			Assert.All(invalidTimestamps, entry => Assert.Equal(0, entry.Value));
+			Assert.All(invalidTimestampsAsync, entry => Assert.Equal(0, entry.Value));
 		}
 
 		[Fact]
-		private void Parse_YoutubeXml()
+		private async Task Parse_YoutubeXml()
 		{
 			SubtitleFormatType targetFormatType = SubtitleFormatType.YoutubeXml;
 
 			Dictionary<string, int> invalidTimestamps = new Dictionary<string, int>();
+			Dictionary<string, int> invalidTimestampsAsync = new Dictionary<string, int>();
 			foreach (string filePath in GetFilesRelatedToParser(targetFormatType))
 			{
 				using FileStream fileStream = new FileStream(filePath, FileMode.Open, FileAccess.Read);
@@ -228,17 +293,24 @@ namespace SubtitlesParserV2.Tests
 
 				// Verify for timestamp
 				invalidTimestamps.Add(filePath, CountInvalidTimestamps(parsingResult.Subtitles));
+
+				// Test async version
+				fileStream.Position = 0;
+				SubtitleParserResultModel parsingResultAsync = await SubtitleParser.ParseStreamAsync(fileStream, Encoding.UTF8, targetFormatType);
+				invalidTimestampsAsync.Add(filePath, CountInvalidTimestamps(parsingResultAsync.Subtitles));
 			}
 			// Verify that every timestamp is valid
 			Assert.All(invalidTimestamps, entry => Assert.Equal(0, entry.Value));
+			Assert.All(invalidTimestampsAsync, entry => Assert.Equal(0, entry.Value));
 		}
 
 		[Fact]
-		private void Parse_MPL2()
+		private async Task Parse_MPL2()
 		{
 			SubtitleFormatType targetFormatType = SubtitleFormatType.MPL2;
 
 			Dictionary<string, int> invalidTimestamps = new Dictionary<string, int>();
+			Dictionary<string, int> invalidTimestampsAsync = new Dictionary<string, int>();
 			foreach (string filePath in GetFilesRelatedToParser(targetFormatType))
 			{
 				using FileStream fileStream = new FileStream(filePath, FileMode.Open, FileAccess.Read);
@@ -246,17 +318,24 @@ namespace SubtitlesParserV2.Tests
 
 				// Verify for timestamp
 				invalidTimestamps.Add(filePath, CountInvalidTimestamps(parsingResult.Subtitles));
+
+				// Test async version
+				fileStream.Position = 0;
+				SubtitleParserResultModel parsingResultAsync = await SubtitleParser.ParseStreamAsync(fileStream, Encoding.UTF8, targetFormatType);
+				invalidTimestampsAsync.Add(filePath, CountInvalidTimestamps(parsingResultAsync.Subtitles));
 			}
 			// Verify that every timestamp is valid
 			Assert.All(invalidTimestamps, entry => Assert.Equal(0, entry.Value));
+			Assert.All(invalidTimestampsAsync, entry => Assert.Equal(0, entry.Value));
 		}
 
 		[Fact]
-		private void Parse_USF()
+		private async Task Parse_USF()
 		{
 			SubtitleFormatType targetFormatType = SubtitleFormatType.USF;
 
 			Dictionary<string, int> invalidTimestamps = new Dictionary<string, int>();
+			Dictionary<string, int> invalidTimestampsAsync = new Dictionary<string, int>();
 			foreach (string filePath in GetFilesRelatedToParser(targetFormatType))
 			{
 				using FileStream fileStream = new FileStream(filePath, FileMode.Open, FileAccess.Read);
@@ -264,9 +343,15 @@ namespace SubtitlesParserV2.Tests
 
 				// Verify for timestamp
 				invalidTimestamps.Add(filePath, CountInvalidTimestamps(parsingResult.Subtitles));
+
+				// Test async version
+				fileStream.Position = 0;
+				SubtitleParserResultModel parsingResultAsync = await SubtitleParser.ParseStreamAsync(fileStream, Encoding.UTF8, targetFormatType);
+				invalidTimestampsAsync.Add(filePath, CountInvalidTimestamps(parsingResultAsync.Subtitles));
 			}
 			// Verify that every timestamp is valid
 			Assert.All(invalidTimestamps, entry => Assert.Equal(0, entry.Value));
+			Assert.All(invalidTimestampsAsync, entry => Assert.Equal(0, entry.Value));
 		}
 	}
 }

--- a/SubtitlesParserV2.Tests/Test_Parsers.cs
+++ b/SubtitlesParserV2.Tests/Test_Parsers.cs
@@ -59,7 +59,7 @@ namespace SubtitlesParserV2.Tests
 			foreach (string filePath in GetFilesRelatedToParser(targetFormatType))
             {
 				using FileStream fileStream = new FileStream(filePath, FileMode.Open, FileAccess.Read);
-				SubtitleParserResultModel parsingResult = SubtitleParser.ParseStream(fileStream, Encoding.UTF8, targetFormatType, false);
+				SubtitleParserResultModel parsingResult = SubtitleParser.ParseStream(fileStream, Encoding.UTF8, targetFormatType);
 
                 // Verify for timestamp
                 invalidTimestamps.Add(filePath, CountInvalidTimestamps(parsingResult.Subtitles));
@@ -77,7 +77,7 @@ namespace SubtitlesParserV2.Tests
 			foreach (string filePath in GetFilesRelatedToParser(targetFormatType))
 			{
 				using FileStream fileStream = new FileStream(filePath, FileMode.Open, FileAccess.Read);
-				SubtitleParserResultModel parsingResult = SubtitleParser.ParseStream(fileStream, Encoding.UTF8, targetFormatType, false);
+				SubtitleParserResultModel parsingResult = SubtitleParser.ParseStream(fileStream, Encoding.UTF8, targetFormatType);
 
 				// Verify for timestamp
 				// NOTE: LRC last subtitle does not have a valid timestamp as per by file format
@@ -96,7 +96,7 @@ namespace SubtitlesParserV2.Tests
 			foreach (string filePath in GetFilesRelatedToParser(targetFormatType))
 			{
 				using FileStream fileStream = new FileStream(filePath, FileMode.Open, FileAccess.Read);
-				SubtitleParserResultModel parsingResult = SubtitleParser.ParseStream(fileStream, Encoding.UTF8, targetFormatType, false);
+				SubtitleParserResultModel parsingResult = SubtitleParser.ParseStream(fileStream, Encoding.UTF8, targetFormatType);
 
 				// Verify for timestamp
 				// NOTE: TMPlayer last subtitle does not have a valid timestamp as per by file format
@@ -115,7 +115,7 @@ namespace SubtitlesParserV2.Tests
 			foreach (string filePath in GetFilesRelatedToParser(targetFormatType))
 			{
 				using FileStream fileStream = new FileStream(filePath, FileMode.Open, FileAccess.Read);
-				SubtitleParserResultModel parsingResult = SubtitleParser.ParseStream(fileStream, Encoding.UTF8, targetFormatType, false);
+				SubtitleParserResultModel parsingResult = SubtitleParser.ParseStream(fileStream, Encoding.UTF8, targetFormatType);
 
 				// Verify for timestamp
 				invalidTimestamps.Add(filePath, CountInvalidTimestamps(parsingResult.Subtitles));
@@ -133,7 +133,7 @@ namespace SubtitlesParserV2.Tests
 			foreach (string filePath in GetFilesRelatedToParser(targetFormatType))
 			{
 				using FileStream fileStream = new FileStream(filePath, FileMode.Open, FileAccess.Read);
-				SubtitleParserResultModel parsingResult = SubtitleParser.ParseStream(fileStream, Encoding.UTF8, targetFormatType, false);
+				SubtitleParserResultModel parsingResult = SubtitleParser.ParseStream(fileStream, Encoding.UTF8, targetFormatType);
 
 				// Verify for timestamp
 				invalidTimestamps.Add(filePath, CountInvalidTimestamps(parsingResult.Subtitles));
@@ -151,7 +151,7 @@ namespace SubtitlesParserV2.Tests
 			foreach (string filePath in GetFilesRelatedToParser(targetFormatType))
 			{
 				using FileStream fileStream = new FileStream(filePath, FileMode.Open, FileAccess.Read);
-				SubtitleParserResultModel parsingResult = SubtitleParser.ParseStream(fileStream, Encoding.UTF8, targetFormatType, false);
+				SubtitleParserResultModel parsingResult = SubtitleParser.ParseStream(fileStream, Encoding.UTF8, targetFormatType);
 
 				// Verify for timestamp
 				invalidTimestamps.Add(filePath, CountInvalidTimestamps(parsingResult.Subtitles));
@@ -169,7 +169,7 @@ namespace SubtitlesParserV2.Tests
 			foreach (string filePath in GetFilesRelatedToParser(targetFormatType))
 			{
 				using FileStream fileStream = new FileStream(filePath, FileMode.Open, FileAccess.Read);
-				SubtitleParserResultModel parsingResult = SubtitleParser.ParseStream(fileStream, Encoding.UTF8, targetFormatType, false);
+				SubtitleParserResultModel parsingResult = SubtitleParser.ParseStream(fileStream, Encoding.UTF8, targetFormatType);
 
 				// Verify for timestamp
 				invalidTimestamps.Add(filePath, CountInvalidTimestamps(parsingResult.Subtitles));
@@ -187,7 +187,7 @@ namespace SubtitlesParserV2.Tests
 			foreach (string filePath in GetFilesRelatedToParser(targetFormatType))
 			{
 				using FileStream fileStream = new FileStream(filePath, FileMode.Open, FileAccess.Read);
-				SubtitleParserResultModel parsingResult = SubtitleParser.ParseStream(fileStream, Encoding.UTF8, targetFormatType, false);
+				SubtitleParserResultModel parsingResult = SubtitleParser.ParseStream(fileStream, Encoding.UTF8, targetFormatType);
 
 				// Verify for timestamp
 				invalidTimestamps.Add(filePath, CountInvalidTimestamps(parsingResult.Subtitles));
@@ -205,7 +205,7 @@ namespace SubtitlesParserV2.Tests
 			foreach (string filePath in GetFilesRelatedToParser(targetFormatType))
 			{
 				using FileStream fileStream = new FileStream(filePath, FileMode.Open, FileAccess.Read);
-				SubtitleParserResultModel parsingResult = SubtitleParser.ParseStream(fileStream, Encoding.UTF8, targetFormatType, false);
+				SubtitleParserResultModel parsingResult = SubtitleParser.ParseStream(fileStream, Encoding.UTF8, targetFormatType);
 
 				// Verify for timestamp
 				// NOTE: SAMI last subtitle does not have a valid timestamp as per by file format
@@ -224,7 +224,7 @@ namespace SubtitlesParserV2.Tests
 			foreach (string filePath in GetFilesRelatedToParser(targetFormatType))
 			{
 				using FileStream fileStream = new FileStream(filePath, FileMode.Open, FileAccess.Read);
-				SubtitleParserResultModel parsingResult = SubtitleParser.ParseStream(fileStream, Encoding.UTF8, targetFormatType, false);
+				SubtitleParserResultModel parsingResult = SubtitleParser.ParseStream(fileStream, Encoding.UTF8, targetFormatType);
 
 				// Verify for timestamp
 				invalidTimestamps.Add(filePath, CountInvalidTimestamps(parsingResult.Subtitles));
@@ -242,7 +242,7 @@ namespace SubtitlesParserV2.Tests
 			foreach (string filePath in GetFilesRelatedToParser(targetFormatType))
 			{
 				using FileStream fileStream = new FileStream(filePath, FileMode.Open, FileAccess.Read);
-				SubtitleParserResultModel parsingResult = SubtitleParser.ParseStream(fileStream, Encoding.UTF8, targetFormatType, false);
+				SubtitleParserResultModel parsingResult = SubtitleParser.ParseStream(fileStream, Encoding.UTF8, targetFormatType);
 
 				// Verify for timestamp
 				invalidTimestamps.Add(filePath, CountInvalidTimestamps(parsingResult.Subtitles));
@@ -260,7 +260,7 @@ namespace SubtitlesParserV2.Tests
 			foreach (string filePath in GetFilesRelatedToParser(targetFormatType))
 			{
 				using FileStream fileStream = new FileStream(filePath, FileMode.Open, FileAccess.Read);
-				SubtitleParserResultModel parsingResult = SubtitleParser.ParseStream(fileStream, Encoding.UTF8, targetFormatType, false);
+				SubtitleParserResultModel parsingResult = SubtitleParser.ParseStream(fileStream, Encoding.UTF8, targetFormatType);
 
 				// Verify for timestamp
 				invalidTimestamps.Add(filePath, CountInvalidTimestamps(parsingResult.Subtitles));

--- a/SubtitlesParserV2.Tests/Test_Parsers.cs
+++ b/SubtitlesParserV2.Tests/Test_Parsers.cs
@@ -65,11 +65,11 @@ namespace SubtitlesParserV2.Tests
                 invalidTimestamps.Add(filePath, CountInvalidTimestamps(parsingResult.Subtitles));
 			}
             // Verify that every timestamp is valid
-            Assert.Contains(invalidTimestamps, entry => entry.Value == 0);
+            Assert.All(invalidTimestamps, entry => Assert.Equal(0, entry.Value));
 		}
 
 		[Fact]
-		private void Parse_LRC()
+		private void  Parse_LRC()
 		{
 			SubtitleFormatType targetFormatType = SubtitleFormatType.LRC;
 
@@ -84,7 +84,7 @@ namespace SubtitlesParserV2.Tests
 				invalidTimestamps.Add(filePath, CountInvalidTimestamps(parsingResult.Subtitles, false, false, true));
 			}
 			// Verify that every timestamp is valid
-			Assert.Contains(invalidTimestamps, entry => entry.Value == 0);
+			Assert.All(invalidTimestamps, entry => Assert.Equal(0, entry.Value));
 		}
 
 		[Fact]
@@ -103,7 +103,7 @@ namespace SubtitlesParserV2.Tests
 				invalidTimestamps.Add(filePath, CountInvalidTimestamps(parsingResult.Subtitles, false, false, true));
 			}
 			// Verify that every timestamp is valid
-			Assert.Contains(invalidTimestamps, entry => entry.Value == 0);
+			Assert.All(invalidTimestamps, entry => Assert.Equal(0, entry.Value));
 		}
 
 		[Fact]
@@ -121,7 +121,7 @@ namespace SubtitlesParserV2.Tests
 				invalidTimestamps.Add(filePath, CountInvalidTimestamps(parsingResult.Subtitles));
 			}
 			// Verify that every timestamp is valid
-			Assert.Contains(invalidTimestamps, entry => entry.Value == 0);
+			Assert.All(invalidTimestamps, entry => Assert.Equal(0, entry.Value));
 		}
 
 		[Fact]
@@ -139,7 +139,7 @@ namespace SubtitlesParserV2.Tests
 				invalidTimestamps.Add(filePath, CountInvalidTimestamps(parsingResult.Subtitles));
 			}
 			// Verify that every timestamp is valid
-			Assert.Contains(invalidTimestamps, entry => entry.Value == 0);
+			Assert.All(invalidTimestamps, entry => Assert.Equal(0, entry.Value));
 		}
 
 		[Fact]
@@ -157,7 +157,7 @@ namespace SubtitlesParserV2.Tests
 				invalidTimestamps.Add(filePath, CountInvalidTimestamps(parsingResult.Subtitles));
 			}
 			// Verify that every timestamp is valid
-			Assert.Contains(invalidTimestamps, entry => entry.Value == 0);
+			Assert.All(invalidTimestamps, entry => Assert.Equal(0, entry.Value));
 		}
 
 		[Fact]
@@ -175,7 +175,7 @@ namespace SubtitlesParserV2.Tests
 				invalidTimestamps.Add(filePath, CountInvalidTimestamps(parsingResult.Subtitles));
 			}
 			// Verify that every timestamp is valid
-			Assert.Contains(invalidTimestamps, entry => entry.Value == 0);
+			Assert.All(invalidTimestamps, entry => Assert.Equal(0, entry.Value));
 		}
 
 		[Fact]
@@ -193,7 +193,7 @@ namespace SubtitlesParserV2.Tests
 				invalidTimestamps.Add(filePath, CountInvalidTimestamps(parsingResult.Subtitles));
 			}
 			// Verify that every timestamp is valid
-			Assert.Contains(invalidTimestamps, entry => entry.Value == 0);
+			Assert.All(invalidTimestamps, entry => Assert.Equal(0, entry.Value));
 		}
 
 		[Fact]
@@ -212,7 +212,7 @@ namespace SubtitlesParserV2.Tests
 				invalidTimestamps.Add(filePath, CountInvalidTimestamps(parsingResult.Subtitles, false, false, true));
 			}
 			// Verify that every timestamp is valid
-			Assert.Contains(invalidTimestamps, entry => entry.Value == 0);
+			Assert.All(invalidTimestamps, entry => Assert.Equal(0, entry.Value));
 		}
 
 		[Fact]
@@ -230,7 +230,7 @@ namespace SubtitlesParserV2.Tests
 				invalidTimestamps.Add(filePath, CountInvalidTimestamps(parsingResult.Subtitles));
 			}
 			// Verify that every timestamp is valid
-			Assert.Contains(invalidTimestamps, entry => entry.Value == 0);
+			Assert.All(invalidTimestamps, entry => Assert.Equal(0, entry.Value));
 		}
 
 		[Fact]
@@ -248,7 +248,7 @@ namespace SubtitlesParserV2.Tests
 				invalidTimestamps.Add(filePath, CountInvalidTimestamps(parsingResult.Subtitles));
 			}
 			// Verify that every timestamp is valid
-			Assert.Contains(invalidTimestamps, entry => entry.Value == 0);
+			Assert.All(invalidTimestamps, entry => Assert.Equal(0, entry.Value));
 		}
 
 		[Fact]
@@ -266,7 +266,7 @@ namespace SubtitlesParserV2.Tests
 				invalidTimestamps.Add(filePath, CountInvalidTimestamps(parsingResult.Subtitles));
 			}
 			// Verify that every timestamp is valid
-			Assert.Contains(invalidTimestamps, entry => entry.Value == 0);
+			Assert.All(invalidTimestamps, entry => Assert.Equal(0, entry.Value));
 		}
 	}
 }

--- a/SubtitlesParserV2/Formats/Parsers/ISubtitlesParser.cs
+++ b/SubtitlesParserV2/Formats/Parsers/ISubtitlesParser.cs
@@ -8,18 +8,16 @@ using SubtitlesParserV2.Models;
 namespace SubtitlesParserV2.Formats.Parsers
 {
 	/// <summary>
-	/// Base interface specifying the required method for a Parser.
-	/// Use <see cref="ISubtitlesParser{TConfig}"/> to overwrite the default configuration of a specific parser,
-	/// if available.
+	/// 
 	/// </summary>
-	public interface ISubtitlesParser<TPart>
+	public interface ISubtitlesParser
 	{
 		/// <summary>
 		/// Parses a subtitles file stream in a list of SubtitleItem using the default configuration.
 		/// </summary>
 		/// <remarks>
 		/// If the parser require additional configuration, this method will uses the
-		/// default configuration. To define your own, consider using <see cref="ISubtitlesParser{TConfig}"/>.
+		/// default configuration. To define your own, consider using <see cref="ISubtitlesParserWithConfig{TConfig}"/>.
 		/// <para>
 		/// <strong>When using this method, make sure you call it from inside a try-catch as exceptions will be thrown on failure to parse.</strong>
 		/// As a alternative, you can use the <see cref="SubtitleParser.ParseStream(Stream, Encoding, IEnumerable{SubtitleFormatType}?, bool)"/> method.
@@ -30,10 +28,18 @@ namespace SubtitlesParserV2.Formats.Parsers
 		/// <returns>The corresponding list of SubtitleItems</returns>
 		List<SubtitleModel> ParseStream(Stream stream, Encoding encoding);
 		Task<List<SubtitleModel>> ParseStreamAsync(Stream stream, Encoding encoding, CancellationToken cancellationToken);
-		IEnumerable<SubtitleModel> ParseAsEnumerable(Stream srtStream, Encoding encoding);
-		IAsyncEnumerable<SubtitleModel> ParseAsEnumerableAsync(Stream stream, Encoding encoding, CancellationToken cancellationToken);
-		IEnumerable<TPart> GetParts(TextReader reader);
-		IAsyncEnumerable<TPart> GetPartsAsync(TextReader reader, CancellationToken cancellationToken = default);
+		IEnumerable<SubtitleModel> ParseStreamConsuming(Stream srtStream, Encoding encoding);
+		IAsyncEnumerable<SubtitleModel> ParseStreamConsumingAsync(Stream stream, Encoding encoding, CancellationToken cancellationToken);
+	}
+	/// <summary>
+	/// Base interface specifying the required method for a Parser.
+	/// Use <see cref="ISubtitlesParserWithConfig{TConfig}"/> to overwrite the default configuration of a specific parser,
+	/// if available.
+	/// </summary>
+	public interface ISubtitlesParser<TPart> : ISubtitlesParser
+	{
+		IEnumerable<TPart> GetParts(Stream reader, Encoding encoding);
+		IAsyncEnumerable<TPart> GetPartsAsync(Stream reader, Encoding encoding, CancellationToken cancellationToken = default);
 		SubtitleModel ParsePart(TPart part, bool isFirstPart);
 	}
 
@@ -46,13 +52,13 @@ namespace SubtitlesParserV2.Formats.Parsers
 	/// // Get the format
 	/// SubtitleFormat format = SubtitleFormat.GetFormat(SubtitleFormatType.MicroDvd);
 	/// // Get the instance as a advanced parser
-	/// ISubtitlesParser<MicroDvdParserConfig> microDvdParserInstance = format.ParserInstance as ISubtitlesParser<MicroDvdParserConfig>;
+	/// ISubtitlesParserWithConfig<MicroDvdParserConfig> microDvdParserInstance = format.ParserInstance as ISubtitlesParserWithConfig<MicroDvdParserConfig>;
 	/// ]]>
 	/// </code>
-	/// Now ensure <strong>microDvdParserInstance</strong> is not null (in case your ParserInstance does not support <![CDATA[ISubtitlesParser<TConfig>)]]>
+	/// Now ensure <strong>microDvdParserInstance</strong> is not null (in case your ParserInstance does not support <![CDATA[ISubtitlesParserWithConfig<TConfig>)]]>
 	/// </para>
 	/// </summary>
-	public interface ISubtitlesParser<TPart,TConfig> // where TConfig : class // Restrict TConfig to a class type to allow it to be a nullable Type
+	public interface ISubtitlesParserWithConfig<in TConfig> : ISubtitlesParser // where TConfig : class // Restrict TConfig to a class type to allow it to be a nullable Type
 	{
 		/// <summary>
 		/// Parses a subtitles file stream in a list of SubtitleItem using a specific configuration.
@@ -65,5 +71,12 @@ namespace SubtitlesParserV2.Formats.Parsers
 		/// <param name="configuration">The configuration for the parser.</param>
 		/// <returns>The corresponding list of SubtitleItems</returns>
 		List<SubtitleModel> ParseStream(Stream stream, Encoding encoding, TConfig configuration);
+	}
+
+	public interface ISubtitlesParserWithConfig<TPart, in TConfig> : ISubtitlesParserWithConfig<TConfig>
+	{
+		IEnumerable<TPart> GetParts(Stream reader, Encoding encoding, TConfig config);
+		IAsyncEnumerable<TPart> GetPartsAsync(Stream reader, Encoding encoding, TConfig config, CancellationToken cancellationToken = default);
+		SubtitleModel ParsePart(TPart part, bool isFirstPart, TConfig config);
 	}
 }

--- a/SubtitlesParserV2/Formats/Parsers/ISubtitlesParser.cs
+++ b/SubtitlesParserV2/Formats/Parsers/ISubtitlesParser.cs
@@ -1,6 +1,8 @@
 ﻿using System.Collections.Generic;
 using System.IO;
 using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
 using SubtitlesParserV2.Models;
 
 namespace SubtitlesParserV2.Formats.Parsers
@@ -10,7 +12,7 @@ namespace SubtitlesParserV2.Formats.Parsers
 	/// Use <see cref="ISubtitlesParser{TConfig}"/> to overwrite the default configuration of a specific parser,
 	/// if available.
 	/// </summary>
-	public interface ISubtitlesParser
+	public interface ISubtitlesParser<TPart>
 	{
 		/// <summary>
 		/// Parses a subtitles file stream in a list of SubtitleItem using the default configuration.
@@ -27,6 +29,12 @@ namespace SubtitlesParserV2.Formats.Parsers
 		/// <param name="encoding">The stream encoding (if known)</param>
 		/// <returns>The corresponding list of SubtitleItems</returns>
 		List<SubtitleModel> ParseStream(Stream stream, Encoding encoding);
+		Task<List<SubtitleModel>> ParseStreamAsync(Stream stream, Encoding encoding, CancellationToken cancellationToken);
+		IEnumerable<SubtitleModel> ParseAsEnumerable(Stream srtStream, Encoding encoding);
+		IAsyncEnumerable<SubtitleModel> ParseAsEnumerableAsync(Stream stream, Encoding encoding, CancellationToken cancellationToken);
+		IEnumerable<TPart> GetParts(TextReader reader);
+		IAsyncEnumerable<TPart> GetPartsAsync(TextReader reader, CancellationToken cancellationToken = default);
+		SubtitleModel ParsePart(TPart part, bool isFirstPart);
 	}
 
 	/// <summary>
@@ -44,7 +52,7 @@ namespace SubtitlesParserV2.Formats.Parsers
 	/// Now ensure <strong>microDvdParserInstance</strong> is not null (in case your ParserInstance does not support <![CDATA[ISubtitlesParser<TConfig>)]]>
 	/// </para>
 	/// </summary>
-	public interface ISubtitlesParser<TConfig> // where TConfig : class // Restrict TConfig to a class type to allow it to be a nullable Type
+	public interface ISubtitlesParser<TPart,TConfig> // where TConfig : class // Restrict TConfig to a class type to allow it to be a nullable Type
 	{
 		/// <summary>
 		/// Parses a subtitles file stream in a list of SubtitleItem using a specific configuration.
@@ -57,5 +65,5 @@ namespace SubtitlesParserV2.Formats.Parsers
 		/// <param name="configuration">The configuration for the parser.</param>
 		/// <returns>The corresponding list of SubtitleItems</returns>
 		List<SubtitleModel> ParseStream(Stream stream, Encoding encoding, TConfig configuration);
-    }
+	}
 }

--- a/SubtitlesParserV2/Formats/Parsers/LrcParser.cs
+++ b/SubtitlesParserV2/Formats/Parsers/LrcParser.cs
@@ -70,14 +70,14 @@ namespace SubtitlesParserV2.Formats.Parsers
 		public List<SubtitleModel> ParseStream(Stream lrcStream, Encoding encoding, LrcParserConfig configuration)
 		{
 			var ret = ParseAsEnumerable(lrcStream, encoding, configuration).ToList();
-			if (ret.Count == 0) throw new ArgumentException(BadFormatMsg);
+			if (ret.Count == 0) throw new FormatException(BadFormatMsg);
 			return ret;
 		}
 
 		public async Task<List<SubtitleModel>> ParseStreamAsync(Stream stream, Encoding encoding, CancellationToken cancellationToken)
 		{
 			var ret = await ParseAsEnumerableAsync(stream, encoding, new LrcParserConfig(), cancellationToken).ToListAsync(cancellationToken);
-			if (ret.Count == 0) throw new ArgumentException(BadFormatMsg);
+			if (ret.Count == 0) throw new FormatException(BadFormatMsg);
 			return ret;
 		}
 
@@ -94,7 +94,7 @@ namespace SubtitlesParserV2.Formats.Parsers
 
 			IEnumerable<LrcSubtitlePart> parts = GetParts(lrcStream, encoding, config).Peekable(out var partsAny);
 			if (!partsAny)
-				throw new ArgumentException(BadFormatMsg);
+				throw new FormatException(BadFormatMsg);
 
 			bool first = true;
 			foreach (LrcSubtitlePart part in parts)
@@ -121,7 +121,7 @@ namespace SubtitlesParserV2.Formats.Parsers
 			var parts = GetPartsAsync(lrcStream, encoding, config, cancellationToken);
 			var partsAny = await parts.PeekableAsync();
 			if (!partsAny)
-				throw new ArgumentException(BadFormatMsg);
+				throw new FormatException(BadFormatMsg);
 
 			bool first = true;
 			await foreach (LrcSubtitlePart part in parts.WithCancellation(cancellationToken))
@@ -197,7 +197,7 @@ namespace SubtitlesParserV2.Formats.Parsers
 				{
 					searchTimeout--;
 					// We didn't find the first valid line and reached the search timeout
-					if (searchTimeout <= 0) throw new ArgumentException("Stream is not in a valid Lrc format (could not find valid timestamp format inside given line timeout)");
+					if (searchTimeout <= 0) throw new FormatException("Stream is not in a valid Lrc format (could not find valid timestamp format inside given line timeout)");
 					continue;
 				}
 
@@ -261,7 +261,7 @@ namespace SubtitlesParserV2.Formats.Parsers
 				{
 					searchTimeout--;
 					// We didn't find the first valid line and reached the search timeout
-					if (searchTimeout <= 0) throw new ArgumentException("Stream is not in a valid Lrc format (could not find valid timestamp format inside given line timeout)");
+					if (searchTimeout <= 0) throw new FormatException("Stream is not in a valid Lrc format (could not find valid timestamp format inside given line timeout)");
 					continue;
 				}
 

--- a/SubtitlesParserV2/Formats/Parsers/LrcParser.cs
+++ b/SubtitlesParserV2/Formats/Parsers/LrcParser.cs
@@ -1,10 +1,14 @@
-﻿using SubtitlesParserV2.Helpers;
+using SubtitlesParserV2.Helpers;
 using SubtitlesParserV2.Models;
 using System;
 using System.Collections.Generic;
 using System.IO;
+using System.Linq;
+using System.Runtime.CompilerServices;
 using System.Text;
 using System.Text.RegularExpressions;
+using System.Threading;
+using System.Threading.Tasks;
 
 namespace SubtitlesParserV2.Formats.Parsers
 {
@@ -20,7 +24,34 @@ namespace SubtitlesParserV2.Formats.Parsers
 		public int FirstLineSearchTimeout { get; set; } = 20;
 	}
 
-	internal class LrcParser : ISubtitlesParser, ISubtitlesParser<LrcParserConfig>
+	/// <summary>
+	/// <para>Parser for the .lrc subtitles files.</para>
+	/// <para><strong>Support</strong> : Core LRC, Enhanced LRC format (A2 extension).
+	/// <strong>NOTE</strong>: Last item end time will always be -1
+	/// </para>
+	/// </summary>
+	/// 
+	/// <!--
+	/// Sources:
+	/// https://en.wikipedia.org/wiki/LRC_(file_format)
+	/// https://docs.fileformat.com/misc/lrc/
+	/// Example:
+	/// [ar:Artist performing]
+	/// [al: Album name]
+	/// [ti: Media title]
+	/// [au: Artist name]
+	/// [length: 0:40]
+	/// # This is a comment, line 6 uses Enhanced LRC format
+	/// 
+	/// [00:12.00] Line 1 lyrics
+	/// [00:17.20] Line 2 lyrics
+	/// [00:21.10] Line 3 lyrics
+	/// [00:24.00] Line 4 lyrics
+	/// [00:28.25] Line 5 lyrics
+	/// [00:29.02] Line 6 <00:34.20>lyrics
+	/// [00:39.00] last lyrics.
+	/// -->
+	internal class LrcParser : ISubtitlesParserWithConfig<LrcSubtitlePart, LrcParserConfig>
 	{
 		// Format : [0000:00.00] / [mm:ss.xx]
 		private static readonly Regex ShortTimestampRegex = new Regex(@"\[(?<M>\d+):(?<S>\d{2})\.(?<X>\d{2})\]", RegexOptions.Compiled);
@@ -29,50 +60,134 @@ namespace SubtitlesParserV2.Formats.Parsers
 		// Format <00:00.00> used inside the lines by the Enhanced LRC format (A2 Extension)
 		private static readonly Regex EnhancedLrcFormatRegex = new Regex(@"<\d{2}:\d{2}\.\d{2}>", RegexOptions.Compiled);
 
+		private const string BadFormatMsg = "Stream is not in a valid Lrc format";
 
 		public List<SubtitleModel> ParseStream(Stream lrcStream, Encoding encoding)
 		{
 			return ParseStream(lrcStream, encoding, new LrcParserConfig());
 		}
 
-		/// <summary>
-		/// <para>Parser for the .lrc subtitles files.</para>
-		/// <para><strong>Support</strong> : Core LRC, Enhanced LRC format (A2 extension).
-		/// <strong>NOTE</strong>: Last item end time will always be -1
-		/// </para>
-		/// </summary>
-		/// 
-		/// <!--
-		/// Sources:
-		/// https://en.wikipedia.org/wiki/LRC_(file_format)
-		/// https://docs.fileformat.com/misc/lrc/
-		/// Example:
-		/// [ar:Artist performing]
-		/// [al: Album name]
-		/// [ti: Media title]
-		/// [au: Artist name]
-		/// [length: 0:40]
-		/// # This is a comment, line 6 uses Enhanced LRC format
-		/// 
-		/// [00:12.00] Line 1 lyrics
-		/// [00:17.20] Line 2 lyrics
-		/// [00:21.10] Line 3 lyrics
-		/// [00:24.00] Line 4 lyrics
-		/// [00:28.25] Line 5 lyrics
-		/// [00:29.02] Line 6 <00:34.20>lyrics
-		/// [00:39.00] last lyrics.
-		/// -->
 		public List<SubtitleModel> ParseStream(Stream lrcStream, Encoding encoding, LrcParserConfig configuration)
 		{
-			// Ensure the stream is seekable and readable
+			var ret = ParseAsEnumerable(lrcStream, encoding, configuration).ToList();
+			if (ret.Count == 0) throw new ArgumentException(BadFormatMsg);
+			return ret;
+		}
+
+		public async Task<List<SubtitleModel>> ParseStreamAsync(Stream stream, Encoding encoding, CancellationToken cancellationToken)
+		{
+			var ret = await ParseAsEnumerableAsync(stream, encoding, new LrcParserConfig(), cancellationToken).ToListAsync(cancellationToken);
+			if (ret.Count == 0) throw new ArgumentException(BadFormatMsg);
+			return ret;
+		}
+
+		public IEnumerable<SubtitleModel> ParseAsEnumerable(Stream lrcStream, Encoding encoding)
+		{
+			return ParseAsEnumerable(lrcStream, encoding, new LrcParserConfig());
+		}
+
+		public IEnumerable<SubtitleModel> ParseAsEnumerable(Stream lrcStream, Encoding encoding, LrcParserConfig config)
+		{
 			StreamHelper.ThrowIfStreamIsNotSeekableOrReadable(lrcStream);
+			// seek the beginning of the stream
 			lrcStream.Position = 0;
 
-			using StreamReader reader = new StreamReader(lrcStream, encoding, true, 1024, true);
-			List<SubtitleModel> items = new List<SubtitleModel>();
+			IEnumerable<LrcSubtitlePart> parts = GetParts(lrcStream, encoding, config).Peekable(out var partsAny);
+			if (!partsAny)
+				throw new ArgumentException(BadFormatMsg);
 
+			bool first = true;
+			foreach (LrcSubtitlePart part in parts)
+			{
+				yield return ParsePart(part, first, config);
+				first = false;
+			}
+		}
+
+		public async IAsyncEnumerable<SubtitleModel> ParseAsEnumerableAsync(Stream lrcStream, Encoding encoding, [EnumeratorCancellation] CancellationToken cancellationToken)
+		{
+			await foreach (var item in ParseAsEnumerableAsync(lrcStream, encoding, new LrcParserConfig(), cancellationToken))
+			{
+				yield return item;
+			}
+		}
+
+		public async IAsyncEnumerable<SubtitleModel> ParseAsEnumerableAsync(Stream lrcStream, Encoding encoding, LrcParserConfig config, [EnumeratorCancellation] CancellationToken cancellationToken)
+		{
+			StreamHelper.ThrowIfStreamIsNotSeekableOrReadable(lrcStream);
+			// seek the beginning of the stream
+			lrcStream.Position = 0;
+
+			var parts = GetPartsAsync(lrcStream, encoding, config, cancellationToken);
+			var partsAny = await parts.PeekableAsync();
+			if (!partsAny)
+				throw new ArgumentException(BadFormatMsg);
+
+			bool first = true;
+			await foreach (LrcSubtitlePart part in parts.WithCancellation(cancellationToken))
+			{
+				yield return ParsePart(part, first, config);
+				first = false;
+			}
+		}
+
+		public IEnumerable<LrcSubtitlePart> GetParts(Stream stream, Encoding encoding)
+		{
+			return GetParts(stream, encoding, new LrcParserConfig());
+		}
+
+		public IEnumerable<LrcSubtitlePart> GetParts(Stream stream, Encoding encoding, LrcParserConfig config)
+		{
+			using StreamReader reader = new StreamReader(stream, encoding, detectEncodingFromByteOrderMarks: true, 1024, true);
+			foreach (var part in GetLrcSubtitleParts(reader, config))
+			{
+				yield return part;
+			}
+		}
+
+		public async IAsyncEnumerable<LrcSubtitlePart> GetPartsAsync(Stream stream, Encoding encoding, [EnumeratorCancellation] CancellationToken cancellationToken = default)
+		{
+			await foreach (var part in GetPartsAsync(stream, encoding, new LrcParserConfig(), cancellationToken))
+			{
+				yield return part;
+			}
+		}
+
+		public async IAsyncEnumerable<LrcSubtitlePart> GetPartsAsync(Stream stream, Encoding encoding, LrcParserConfig config, [EnumeratorCancellation] CancellationToken cancellationToken = default)
+		{
+			using StreamReader reader = new StreamReader(stream, encoding, detectEncodingFromByteOrderMarks: true, 1024, true);
+			await foreach (var part in GetLrcSubtitlePartsAsync(reader, config, cancellationToken))
+			{
+				yield return part;
+			}
+		}
+
+		public SubtitleModel ParsePart(LrcSubtitlePart part, bool isFirstPart)
+		{
+			return ParsePart(part, isFirstPart, new LrcParserConfig());
+		}
+
+		public SubtitleModel ParsePart(LrcSubtitlePart part, bool isFirstPart, LrcParserConfig config)
+		{
+			return new SubtitleModel()
+			{
+				StartTime = part.StartTime,
+				EndTime = part.EndTime,
+				Lines = new List<string> { part.Text }
+			};
+		}
+
+		/// <summary>
+		/// Enumerates the subtitle parts in an LRC file.
+		/// </summary>
+		/// <param name="reader">The textreader associated with the LRC file</param>
+		/// <param name="config">The parser configuration</param>
+		/// <returns>An IEnumerable of LrcSubtitlePart objects</returns>
+		private static IEnumerable<LrcSubtitlePart> GetLrcSubtitleParts(TextReader reader, LrcParserConfig config)
+		{
 			string? lastLine = null;
 			string? currentLine = null;
+			int searchTimeout = config.FirstLineSearchTimeout;
 
 			// Read the file line by line
 			while ((currentLine = reader.ReadLine()) != null)
@@ -80,9 +195,10 @@ namespace SubtitlesParserV2.Formats.Parsers
 				// Validate the current line format early
 				if (!IsValidLrcLine(currentLine))
 				{
-					configuration.FirstLineSearchTimeout--;
+					searchTimeout--;
 					// We didn't find the first valid line and reached the search timeout
-					if (configuration.FirstLineSearchTimeout <= 0) throw new ArgumentException("Stream is not in a valid Lrc format (could not find valid timestamp format inside given line timeout)");
+					if (searchTimeout <= 0) throw new ArgumentException("Stream is not in a valid Lrc format (could not find valid timestamp format inside given line timeout)");
+					continue;
 				}
 
 				// Process the previous line now that we know it's end time with the current line
@@ -93,12 +209,12 @@ namespace SubtitlesParserV2.Formats.Parsers
 
 					if (startTime.HasValue && endTime.HasValue)
 					{
-						items.Add(new SubtitleModel
+						yield return new LrcSubtitlePart
 						{
 							StartTime = startTime.Value,
 							EndTime = endTime.Value,
-							Lines = new List<string> { CleanLrcLine(lastLine) }
-						});
+							Text = CleanLrcLine(lastLine)
+						};
 					}
 				}
 
@@ -108,19 +224,82 @@ namespace SubtitlesParserV2.Formats.Parsers
 			// Process the last line if it exists
 			if (lastLine != null)
 			{
-				int startTime = ParseLrcTime(lastLine);
+				int? startTime = ParseLrcTime(lastLine);
 
-				items.Add(new SubtitleModel
+				if (startTime.HasValue)
 				{
-					StartTime = startTime,
-					EndTime = -1, // We can't know the end time of the last line of our file
-					Lines = new List<string> { CleanLrcLine(lastLine) }
-				});
+					yield return new LrcSubtitlePart
+					{
+						StartTime = startTime.Value,
+						EndTime = -1, // We can't know the end time of the last line of our file
+						Text = CleanLrcLine(lastLine)
+					};
+				}
+			}
+		}
+
+		/// <summary>
+		/// Asynchronously enumerates the subtitle parts in an LRC file.
+		/// </summary>
+		/// <param name="reader">The textreader associated with the LRC file</param>
+		/// <param name="config">The parser configuration</param>
+		/// <param name="cancellationToken">Cancellation token</param>
+		/// <returns>An IAsyncEnumerable of LrcSubtitlePart objects</returns>
+		private static async IAsyncEnumerable<LrcSubtitlePart> GetLrcSubtitlePartsAsync(TextReader reader, LrcParserConfig config, [EnumeratorCancellation] CancellationToken cancellationToken = default)
+		{
+			string? lastLine = null;
+			string? currentLine = null;
+			int searchTimeout = config.FirstLineSearchTimeout;
+
+			// Read the file line by line
+			while ((currentLine = await reader.ReadLineAsync()) != null)
+			{
+				cancellationToken.ThrowIfCancellationRequested();
+
+				// Validate the current line format early
+				if (!IsValidLrcLine(currentLine))
+				{
+					searchTimeout--;
+					// We didn't find the first valid line and reached the search timeout
+					if (searchTimeout <= 0) throw new ArgumentException("Stream is not in a valid Lrc format (could not find valid timestamp format inside given line timeout)");
+					continue;
+				}
+
+				// Process the previous line now that we know it's end time with the current line
+				if (lastLine != null)
+				{
+					int? startTime = ParseLrcTime(lastLine);
+					int? endTime = ParseLrcTime(currentLine);
+
+					if (startTime.HasValue && endTime.HasValue)
+					{
+						yield return new LrcSubtitlePart
+						{
+							StartTime = startTime.Value,
+							EndTime = endTime.Value,
+							Text = CleanLrcLine(lastLine)
+						};
+					}
+				}
+
+				lastLine = currentLine;
 			}
 
-			// Verify we have parsed at least 1 subtitle
-			if (items.Count == 0) throw new ArgumentException("Stream is not in a valid Lrc format");
-			return items;
+			// Process the last line if it exists
+			if (lastLine != null)
+			{
+				int? startTime = ParseLrcTime(lastLine);
+
+				if (startTime.HasValue)
+				{
+					yield return new LrcSubtitlePart
+					{
+						StartTime = startTime.Value,
+						EndTime = -1, // We can't know the end time of the last line of our file
+						Text = CleanLrcLine(lastLine)
+					};
+				}
+			}
 		}
 
 		/// <summary>
@@ -150,9 +329,9 @@ namespace SubtitlesParserV2.Formats.Parsers
 		/// Example:
 		/// [00:00.xx] My lyrics!
 		/// </summary>
-		/// <returns>The timestamp in milliseconds or -1 if it could not be parsed.</returns>
+		/// <returns>The timestamp in milliseconds or null if it could not be parsed.</returns>
 		/// <param name="line">The line containing the timestamp.</param>
-		private static int ParseLrcTime(string line)
+		private static int? ParseLrcTime(string line)
 		{
 			Match match = ShortTimestampRegex.Match(line);
 			if (!match.Success)
@@ -172,7 +351,17 @@ namespace SubtitlesParserV2.Formats.Parsers
 				return (int)new TimeSpan(0, hours, minutes, seconds, milliseconds).TotalMilliseconds;
 			}
 
-			return -1;
+			return null;
 		}
+	}
+
+	/// <summary>
+	/// Represents a parsed LRC subtitle part before conversion to SubtitleModel
+	/// </summary>
+	internal class LrcSubtitlePart
+	{
+		public int StartTime { get; set; }
+		public int EndTime { get; set; }
+		public string Text { get; set; } = string.Empty;
 	}
 }

--- a/SubtitlesParserV2/Formats/Parsers/LrcParser.cs
+++ b/SubtitlesParserV2/Formats/Parsers/LrcParser.cs
@@ -81,7 +81,7 @@ namespace SubtitlesParserV2.Formats.Parsers
 			return ret;
 		}
 
-		public IEnumerable<SubtitleModel> ParseAsEnumerable(Stream lrcStream, Encoding encoding)
+		public IEnumerable<SubtitleModel> ParseStreamConsuming(Stream lrcStream, Encoding encoding)
 		{
 			return ParseAsEnumerable(lrcStream, encoding, new LrcParserConfig());
 		}
@@ -104,7 +104,7 @@ namespace SubtitlesParserV2.Formats.Parsers
 			}
 		}
 
-		public async IAsyncEnumerable<SubtitleModel> ParseAsEnumerableAsync(Stream lrcStream, Encoding encoding, [EnumeratorCancellation] CancellationToken cancellationToken)
+		public async IAsyncEnumerable<SubtitleModel> ParseStreamConsumingAsync(Stream lrcStream, Encoding encoding, [EnumeratorCancellation] CancellationToken cancellationToken)
 		{
 			await foreach (var item in ParseAsEnumerableAsync(lrcStream, encoding, new LrcParserConfig(), cancellationToken))
 			{

--- a/SubtitlesParserV2/Formats/Parsers/LrcParser.cs
+++ b/SubtitlesParserV2/Formats/Parsers/LrcParser.cs
@@ -118,8 +118,8 @@ namespace SubtitlesParserV2.Formats.Parsers
 			// seek the beginning of the stream
 			lrcStream.Position = 0;
 
-			var parts = GetPartsAsync(lrcStream, encoding, config, cancellationToken);
-			var partsAny = await parts.PeekableAsync();
+			var partsOld = GetPartsAsync(lrcStream, encoding, cancellationToken);
+			var (parts,partsAny) = await partsOld.PeekableAsync();
 			if (!partsAny)
 				throw new FormatException(BadFormatMsg);
 
@@ -197,7 +197,7 @@ namespace SubtitlesParserV2.Formats.Parsers
 				{
 					searchTimeout--;
 					// We didn't find the first valid line and reached the search timeout
-					if (searchTimeout <= 0) throw new FormatException("Stream is not in a valid Lrc format (could not find valid timestamp format inside given line timeout)");
+					if (searchTimeout <= 0) throw new ArgumentException("Stream is not in a valid Lrc format (could not find valid timestamp format inside given line timeout)");
 					continue;
 				}
 
@@ -261,7 +261,7 @@ namespace SubtitlesParserV2.Formats.Parsers
 				{
 					searchTimeout--;
 					// We didn't find the first valid line and reached the search timeout
-					if (searchTimeout <= 0) throw new FormatException("Stream is not in a valid Lrc format (could not find valid timestamp format inside given line timeout)");
+					if (searchTimeout <= 0) throw new ArgumentException("Stream is not in a valid Lrc format (could not find valid timestamp format inside given line timeout)");
 					continue;
 				}
 

--- a/SubtitlesParserV2/Formats/Parsers/MicroDvdParser.cs
+++ b/SubtitlesParserV2/Formats/Parsers/MicroDvdParser.cs
@@ -36,7 +36,7 @@ namespace SubtitlesParserV2.Formats.Parsers
 	/// <remarks>
 	/// If no framerate are found, will default to 25. To force specific settings, you can use
 	/// <see cref="SubtitleFormat.GetFormat(SubtitleFormatType)"/> and define the <see cref="SubtitleFormat.ParserInstance"/>
-	/// as a <see cref="ISubtitlesParser{MicroDvdParserConfig}"/>.
+	/// as a <see cref="ISubtitlesParserWithConfig{MicroDvdParserConfig}"/>.
 	/// </remarks>
 	/// <!--
 	/// Sources:

--- a/SubtitlesParserV2/Formats/Parsers/MicroDvdParser.cs
+++ b/SubtitlesParserV2/Formats/Parsers/MicroDvdParser.cs
@@ -123,8 +123,8 @@ namespace SubtitlesParserV2.Formats.Parsers
 			// seek the beginning of the stream
 			subStream.Position = 0;
 
-			var parts = GetPartsAsync(subStream, encoding, config, cancellationToken);
-			var partsAny = await parts.PeekableAsync();
+			var partsOld = GetPartsAsync(subStream, encoding, cancellationToken);
+			var (parts,partsAny) = await partsOld.PeekableAsync();
 			if (!partsAny)
 				throw new FormatException(BadFormatMsg);
 

--- a/SubtitlesParserV2/Formats/Parsers/MicroDvdParser.cs
+++ b/SubtitlesParserV2/Formats/Parsers/MicroDvdParser.cs
@@ -75,14 +75,14 @@ namespace SubtitlesParserV2.Formats.Parsers
 		public List<SubtitleModel> ParseStream(Stream subStream, Encoding encoding, MicroDvdParserConfig config)
 		{
 			var ret = ParseAsEnumerable(subStream, encoding, config).ToList();
-			if (ret.Count == 0) throw new ArgumentException(BadFormatMsg);
+			if (ret.Count == 0) throw new FormatException(BadFormatMsg);
 			return ret;
 		}
 
 		public async Task<List<SubtitleModel>> ParseStreamAsync(Stream stream, Encoding encoding, CancellationToken cancellationToken)
 		{
 			var ret = await ParseAsEnumerableAsync(stream, encoding, new MicroDvdParserConfig(), cancellationToken).ToListAsync(cancellationToken);
-			if (ret.Count == 0) throw new ArgumentException(BadFormatMsg);
+			if (ret.Count == 0) throw new FormatException(BadFormatMsg);
 			return ret;
 		}
 
@@ -99,7 +99,7 @@ namespace SubtitlesParserV2.Formats.Parsers
 
 			IEnumerable<MicroDvdSubtitlePart> parts = GetParts(subStream, encoding, config).Peekable(out var partsAny);
 			if (!partsAny)
-				throw new ArgumentException(BadFormatMsg);
+				throw new FormatException(BadFormatMsg);
 
 			bool first = true;
 			foreach (MicroDvdSubtitlePart part in parts)
@@ -126,7 +126,7 @@ namespace SubtitlesParserV2.Formats.Parsers
 			var parts = GetPartsAsync(subStream, encoding, config, cancellationToken);
 			var partsAny = await parts.PeekableAsync();
 			if (!partsAny)
-				throw new ArgumentException(BadFormatMsg);
+				throw new FormatException(BadFormatMsg);
 
 			bool first = true;
 			await foreach (MicroDvdSubtitlePart part in parts.WithCancellation(cancellationToken))

--- a/SubtitlesParserV2/Formats/Parsers/MicroDvdParser.cs
+++ b/SubtitlesParserV2/Formats/Parsers/MicroDvdParser.cs
@@ -51,7 +51,7 @@ namespace SubtitlesParserV2.Formats.Parsers
 	/// {509}{629}Drink up water yo ho!
 	/// {635}{755}We eat and don't give a hoot.
 	/// -->
-	internal class MicroDvdParser : ISubtitlesParser<MicroDvdSubtitlePart, MicroDvdParserConfig>
+	internal class MicroDvdParser : ISubtitlesParserWithConfig<MicroDvdSubtitlePart, MicroDvdParserConfig>
 	{
 		private static readonly Type CurrentType = typeof(MicroDvdParser);
 		// Alternative for static class, create a logger with the full namespace name
@@ -86,7 +86,7 @@ namespace SubtitlesParserV2.Formats.Parsers
 			return ret;
 		}
 
-		public IEnumerable<SubtitleModel> ParseAsEnumerable(Stream subStream, Encoding encoding)
+		public IEnumerable<SubtitleModel> ParseStreamConsuming(Stream subStream, Encoding encoding)
 		{
 			return ParseAsEnumerable(subStream, encoding, new MicroDvdParserConfig());
 		}
@@ -109,7 +109,7 @@ namespace SubtitlesParserV2.Formats.Parsers
 			}
 		}
 
-		public async IAsyncEnumerable<SubtitleModel> ParseAsEnumerableAsync(Stream subStream, Encoding encoding, [EnumeratorCancellation] CancellationToken cancellationToken)
+		public async IAsyncEnumerable<SubtitleModel> ParseStreamConsumingAsync(Stream subStream, Encoding encoding, [EnumeratorCancellation] CancellationToken cancellationToken)
 		{
 			await foreach (var item in ParseAsEnumerableAsync(subStream, encoding, new MicroDvdParserConfig(), cancellationToken))
 			{

--- a/SubtitlesParserV2/Formats/Parsers/Mpl2Parser.cs
+++ b/SubtitlesParserV2/Formats/Parsers/Mpl2Parser.cs
@@ -68,8 +68,8 @@ namespace SubtitlesParserV2.Formats.Parsers
 			// seek the beginning of the stream
 			mpl2Stream.Position = 0;
 
-			var parts = GetPartsAsync(mpl2Stream, encoding, cancellationToken);
-			var partsAny = await parts.PeekableAsync();
+			var partsOld = GetPartsAsync(mpl2Stream, encoding, cancellationToken);
+			var (parts,partsAny) = await partsOld.PeekableAsync();
 			if (!partsAny)
 				throw new FormatException(BadFormatMsg);
 
@@ -172,7 +172,7 @@ namespace SubtitlesParserV2.Formats.Parsers
 			// Parse the line
 			string[] parts = line.Split(']', 3);
 			// Ensure there is at least 3 string ( [START] & [END] & CONTENT )
-			if (parts.Length < 3) throw new FormatException("Stream line is not in a valid Mpl2 format.");
+			if (parts.Length < 3) throw new ArgumentException("Stream line is not in a valid Mpl2 format.");
 
 			// Two first elements are the timestamp, what follow it the content
 			string content = parts[2];
@@ -199,14 +199,14 @@ namespace SubtitlesParserV2.Formats.Parsers
 			// Ensure there is at least 2 matches ( [START] & [END] )
 			// NOTE: We could default to defining time to -1 when invalid, however due to the file having almost no unique feature,
 			// a invalid timestamp is the best way to detect that the current stream is not in Mpl2 format and stop parsing early.
-			if (matchs.Groups.Count < 2) throw new FormatException("Stream line is not in a valid Mpl2 format.");
+			if (matchs.Groups.Count < 2) throw new ArgumentException("Stream line is not in a valid Mpl2 format.");
 
 			int startTime = 0;
 			int endTime = 0;
 			// Parse time, throw error if it fail
 			if (!int.TryParse(matchs?.Groups["START"]?.Value, out startTime) || !int.TryParse(matchs?.Groups["END"]?.Value, out endTime))
 			{
-				throw new FormatException("Stream line has invalid characters at positions used for time. Stream is not a valid Mpl2 format.");
+				throw new ArgumentException("Stream line has invalid characters at positions used for time. Stream is not a valid Mpl2 format.");
 			}
 			return ((int)new TimeSpan(0, 0, startTime).TotalMilliseconds, (int)new TimeSpan(0, 0, endTime).TotalMilliseconds);
 		}

--- a/SubtitlesParserV2/Formats/Parsers/Mpl2Parser.cs
+++ b/SubtitlesParserV2/Formats/Parsers/Mpl2Parser.cs
@@ -33,14 +33,14 @@ namespace SubtitlesParserV2.Formats.Parsers
 		public List<SubtitleModel> ParseStream(Stream mpl2Stream, Encoding encoding)
 		{
 			var ret = ParseStreamConsuming(mpl2Stream, encoding).ToList();
-			if (ret.Count == 0) throw new ArgumentException(BadFormatMsg);
+			if (ret.Count == 0) throw new FormatException(BadFormatMsg);
 			return ret;
 		}
 
 		public async Task<List<SubtitleModel>> ParseStreamAsync(Stream stream, Encoding encoding, CancellationToken cancellationToken)
 		{
 			var ret = await ParseStreamConsumingAsync(stream, encoding, cancellationToken).ToListAsync(cancellationToken);
-			if (ret.Count == 0) throw new ArgumentException(BadFormatMsg);
+			if (ret.Count == 0) throw new FormatException(BadFormatMsg);
 			return ret;
 		}
 
@@ -52,7 +52,7 @@ namespace SubtitlesParserV2.Formats.Parsers
 
 			IEnumerable<Mpl2SubtitlePart> parts = GetParts(mpl2Stream, encoding).Peekable(out var partsAny);
 			if (!partsAny)
-				throw new ArgumentException(BadFormatMsg);
+				throw new FormatException(BadFormatMsg);
 
 			bool first = true;
 			foreach (Mpl2SubtitlePart part in parts)
@@ -71,7 +71,7 @@ namespace SubtitlesParserV2.Formats.Parsers
 			var parts = GetPartsAsync(mpl2Stream, encoding, cancellationToken);
 			var partsAny = await parts.PeekableAsync();
 			if (!partsAny)
-				throw new ArgumentException(BadFormatMsg);
+				throw new FormatException(BadFormatMsg);
 
 			bool first = true;
 			await foreach (Mpl2SubtitlePart part in parts.WithCancellation(cancellationToken))
@@ -172,7 +172,7 @@ namespace SubtitlesParserV2.Formats.Parsers
 			// Parse the line
 			string[] parts = line.Split(']', 3);
 			// Ensure there is at least 3 string ( [START] & [END] & CONTENT )
-			if (parts.Length < 3) throw new ArgumentException("Stream line is not in a valid Mpl2 format.");
+			if (parts.Length < 3) throw new FormatException("Stream line is not in a valid Mpl2 format.");
 
 			// Two first elements are the timestamp, what follow it the content
 			string content = parts[2];
@@ -199,14 +199,14 @@ namespace SubtitlesParserV2.Formats.Parsers
 			// Ensure there is at least 2 matches ( [START] & [END] )
 			// NOTE: We could default to defining time to -1 when invalid, however due to the file having almost no unique feature,
 			// a invalid timestamp is the best way to detect that the current stream is not in Mpl2 format and stop parsing early.
-			if (matchs.Groups.Count < 2) throw new ArgumentException("Stream line is not in a valid Mpl2 format.");
+			if (matchs.Groups.Count < 2) throw new FormatException("Stream line is not in a valid Mpl2 format.");
 
 			int startTime = 0;
 			int endTime = 0;
 			// Parse time, throw error if it fail
 			if (!int.TryParse(matchs?.Groups["START"]?.Value, out startTime) || !int.TryParse(matchs?.Groups["END"]?.Value, out endTime))
 			{
-				throw new ArgumentException("Stream line has invalid characters at positions used for time. Stream is not a valid Mpl2 format.");
+				throw new FormatException("Stream line has invalid characters at positions used for time. Stream is not a valid Mpl2 format.");
 			}
 			return ((int)new TimeSpan(0, 0, startTime).TotalMilliseconds, (int)new TimeSpan(0, 0, endTime).TotalMilliseconds);
 		}

--- a/SubtitlesParserV2/Formats/Parsers/Mpl2Parser.cs
+++ b/SubtitlesParserV2/Formats/Parsers/Mpl2Parser.cs
@@ -32,19 +32,19 @@ namespace SubtitlesParserV2.Formats.Parsers
 
 		public List<SubtitleModel> ParseStream(Stream mpl2Stream, Encoding encoding)
 		{
-			var ret = ParseAsEnumerable(mpl2Stream, encoding).ToList();
+			var ret = ParseStreamConsuming(mpl2Stream, encoding).ToList();
 			if (ret.Count == 0) throw new ArgumentException(BadFormatMsg);
 			return ret;
 		}
 
 		public async Task<List<SubtitleModel>> ParseStreamAsync(Stream stream, Encoding encoding, CancellationToken cancellationToken)
 		{
-			var ret = await ParseAsEnumerableAsync(stream, encoding, cancellationToken).ToListAsync(cancellationToken);
+			var ret = await ParseStreamConsumingAsync(stream, encoding, cancellationToken).ToListAsync(cancellationToken);
 			if (ret.Count == 0) throw new ArgumentException(BadFormatMsg);
 			return ret;
 		}
 
-		public IEnumerable<SubtitleModel> ParseAsEnumerable(Stream mpl2Stream, Encoding encoding)
+		public IEnumerable<SubtitleModel> ParseStreamConsuming(Stream mpl2Stream, Encoding encoding)
 		{
 			StreamHelper.ThrowIfStreamIsNotSeekableOrReadable(mpl2Stream);
 			// seek the beginning of the stream
@@ -62,7 +62,7 @@ namespace SubtitlesParserV2.Formats.Parsers
 			}
 		}
 
-		public async IAsyncEnumerable<SubtitleModel> ParseAsEnumerableAsync(Stream mpl2Stream, Encoding encoding, [EnumeratorCancellation] CancellationToken cancellationToken)
+		public async IAsyncEnumerable<SubtitleModel> ParseStreamConsumingAsync(Stream mpl2Stream, Encoding encoding, [EnumeratorCancellation] CancellationToken cancellationToken)
 		{
 			StreamHelper.ThrowIfStreamIsNotSeekableOrReadable(mpl2Stream);
 			// seek the beginning of the stream

--- a/SubtitlesParserV2/Formats/Parsers/SamiParser.cs
+++ b/SubtitlesParserV2/Formats/Parsers/SamiParser.cs
@@ -47,14 +47,14 @@ namespace SubtitlesParserV2.Formats.Parsers
 		public List<SubtitleModel> ParseStream(Stream samiStream, Encoding encoding, SamiParserConfig config)
 		{
 			var ret = ParseAsEnumerable(samiStream, encoding, config).ToList();
-			if (ret.Count == 0) throw new ArgumentException(BadFormatMsg);
+			if (ret.Count == 0) throw new FormatException(BadFormatMsg);
 			return ret;
 		}
 
 		public async Task<List<SubtitleModel>> ParseStreamAsync(Stream stream, Encoding encoding, CancellationToken cancellationToken)
 		{
 			var ret = await ParseAsEnumerableAsync(stream, encoding, new SamiParserConfig(), cancellationToken).ToListAsync(cancellationToken);
-			if (ret.Count == 0) throw new ArgumentException(BadFormatMsg);
+			if (ret.Count == 0) throw new FormatException(BadFormatMsg);
 			return ret;
 		}
 
@@ -71,7 +71,7 @@ namespace SubtitlesParserV2.Formats.Parsers
 
 			IEnumerable<SamiSubtitlePart> parts = GetParts(samiStream, encoding, config).Peekable(out var partsAny);
 			if (!partsAny)
-				throw new ArgumentException(BadFormatMsg);
+				throw new FormatException(BadFormatMsg);
 
 			bool first = true;
 			foreach (SamiSubtitlePart part in parts)
@@ -98,7 +98,7 @@ namespace SubtitlesParserV2.Formats.Parsers
 			var parts = GetPartsAsync(samiStream, encoding, config, cancellationToken);
 			var partsAny = await parts.PeekableAsync();
 			if (!partsAny)
-				throw new ArgumentException(BadFormatMsg);
+				throw new FormatException(BadFormatMsg);
 
 			bool first = true;
 			await foreach (SamiSubtitlePart part in parts.WithCancellation(cancellationToken))
@@ -176,7 +176,7 @@ namespace SubtitlesParserV2.Formats.Parsers
 			string? line = reader.ReadLine();
 			// Ensure the file is a sami file by verifying the first line
 			if (!line?.Equals("<SAMI>", StringComparison.OrdinalIgnoreCase) ?? true) 
-				throw new ArgumentException("Could not find SAMI element at line 1.");
+				throw new FormatException("Could not find SAMI element at line 1.");
 
 			// Loop until last line was processed
 			do
@@ -280,7 +280,7 @@ namespace SubtitlesParserV2.Formats.Parsers
 			string? line = await reader.ReadLineAsync();
 			// Ensure the file is a sami file by verifying the first line
 			if (!line?.Equals("<SAMI>", StringComparison.OrdinalIgnoreCase) ?? true) 
-				throw new ArgumentException("Could not find SAMI element at line 1.");
+				throw new FormatException("Could not find SAMI element at line 1.");
 
 			// Loop until last line was processed
 			do

--- a/SubtitlesParserV2/Formats/Parsers/SamiParser.cs
+++ b/SubtitlesParserV2/Formats/Parsers/SamiParser.cs
@@ -95,8 +95,8 @@ namespace SubtitlesParserV2.Formats.Parsers
 			// seek the beginning of the stream
 			samiStream.Position = 0;
 
-			var parts = GetPartsAsync(samiStream, encoding, config, cancellationToken);
-			var partsAny = await parts.PeekableAsync();
+			var partsOld = GetPartsAsync(samiStream, encoding, cancellationToken);
+			var (parts,partsAny) = await partsOld.PeekableAsync();
 			if (!partsAny)
 				throw new FormatException(BadFormatMsg);
 
@@ -176,7 +176,7 @@ namespace SubtitlesParserV2.Formats.Parsers
 			string? line = reader.ReadLine();
 			// Ensure the file is a sami file by verifying the first line
 			if (!line?.Equals("<SAMI>", StringComparison.OrdinalIgnoreCase) ?? true) 
-				throw new FormatException("Could not find SAMI element at line 1.");
+				throw new ArgumentException("Could not find SAMI element at line 1.");
 
 			// Loop until last line was processed
 			do
@@ -280,7 +280,7 @@ namespace SubtitlesParserV2.Formats.Parsers
 			string? line = await reader.ReadLineAsync();
 			// Ensure the file is a sami file by verifying the first line
 			if (!line?.Equals("<SAMI>", StringComparison.OrdinalIgnoreCase) ?? true) 
-				throw new FormatException("Could not find SAMI element at line 1.");
+				throw new ArgumentException("Could not find SAMI element at line 1.");
 
 			// Loop until last line was processed
 			do

--- a/SubtitlesParserV2/Formats/Parsers/SamiParser.cs
+++ b/SubtitlesParserV2/Formats/Parsers/SamiParser.cs
@@ -35,7 +35,7 @@ namespace SubtitlesParserV2.Formats.Parsers
 	/// https://en.wikipedia.org/wiki/SAMI
 	/// https://docs.fileformat.com/video/sami/
 	/// -->
-	internal class SamiParser : ISubtitlesParser<SamiSubtitlePart>, ISubtitlesParser<SamiSubtitlePart, SamiParserConfig>
+	internal class SamiParser : ISubtitlesParserWithConfig<SamiSubtitlePart, SamiParserConfig>
 	{
 		private const string BadFormatMsg = "Stream is not in a valid Sami format";
 
@@ -58,7 +58,7 @@ namespace SubtitlesParserV2.Formats.Parsers
 			return ret;
 		}
 
-		public IEnumerable<SubtitleModel> ParseAsEnumerable(Stream samiStream, Encoding encoding)
+		public IEnumerable<SubtitleModel> ParseStreamConsuming(Stream samiStream, Encoding encoding)
 		{
 			return ParseAsEnumerable(samiStream, encoding, new SamiParserConfig());
 		}
@@ -81,7 +81,7 @@ namespace SubtitlesParserV2.Formats.Parsers
 			}
 		}
 
-		public async IAsyncEnumerable<SubtitleModel> ParseAsEnumerableAsync(Stream samiStream, Encoding encoding, [EnumeratorCancellation] CancellationToken cancellationToken)
+		public async IAsyncEnumerable<SubtitleModel> ParseStreamConsumingAsync(Stream samiStream, Encoding encoding, [EnumeratorCancellation] CancellationToken cancellationToken)
 		{
 			await foreach (var item in ParseAsEnumerableAsync(samiStream, encoding, new SamiParserConfig(), cancellationToken))
 			{
@@ -148,7 +148,15 @@ namespace SubtitlesParserV2.Formats.Parsers
 				Lines = part.Lines
 			};
 		}
-
+		public SubtitleModel ParsePart(SamiSubtitlePart part, bool isFirstPart, SamiParserConfig config)
+		{
+			return new SubtitleModel()
+			{
+				StartTime = part.StartTime,
+				EndTime = part.EndTime,
+				Lines = part.Lines
+			};
+		}
 		/// <summary>
 		/// Enumerates the subtitle parts in a SAMI file.
 		/// </summary>

--- a/SubtitlesParserV2/Formats/Parsers/SrtParser.cs
+++ b/SubtitlesParserV2/Formats/Parsers/SrtParser.cs
@@ -81,8 +81,8 @@ namespace SubtitlesParserV2.Formats.Parsers
 
 			// Create a StreamReader & configure it to leave the main srtStream open when disposing
 
-			var srtSubParts = GetPartsAsync(srtStream, encoding, cancellationToken); // This is a lazy list, not yet into memory
-			var srtSubPartsAny = await srtSubParts.PeekableAsync();
+			var srtSubPartsOld = GetPartsAsync(srtStream, encoding, cancellationToken); // This is a lazy list, not yet into memory
+			var (srtSubParts, srtSubPartsAny) = await srtSubPartsOld.PeekableAsync();
 			if(!srtSubPartsAny) throw new FormatException(NoPartsMsg);
 			await foreach (string part in srtSubParts)
 				yield return ParsePart(part, srtSubPartsAny);

--- a/SubtitlesParserV2/Formats/Parsers/SsaParser.cs
+++ b/SubtitlesParserV2/Formats/Parsers/SsaParser.cs
@@ -1,9 +1,12 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
+using System.Runtime.CompilerServices;
 using System.Text;
 using System.Text.RegularExpressions;
+using System.Threading;
+using System.Threading.Tasks;
 using SubtitlesParserV2.Helpers;
 using SubtitlesParserV2.Helpers.Formats;
 using SubtitlesParserV2.Models;
@@ -42,20 +45,140 @@ namespace SubtitlesParserV2.Formats.Parsers
 	/// Format: Marked, Start, End, Style, Name, MarginL, MarginR, MarginV, Effect, Text
 	/// Dialogue: Marked=0,0:00:01.18,0:00:06.85,DefaultVCD, NTP,0000,0000,0000,,{\pos(400,570)}Like an angel with pity on nobody
 	/// -->
-	internal class SsaParser : ISubtitlesParser
+	internal class SsaParser : ISubtitlesParser<SsaSubtitlePart>
 	{
+		private const string BadFormatMsg = "Stream is not in a valid Ssa format";
 
 		// Methods ------------------------------------------------------------------
 
 		public List<SubtitleModel> ParseStream(Stream ssaStream, Encoding encoding)
 		{
+			var ret = ParseAsEnumerable(ssaStream, encoding).ToList();
+			if (ret.Count == 0) throw new ArgumentException(BadFormatMsg);
+			return ret;
+		}
+
+		public async Task<List<SubtitleModel>> ParseStreamAsync(Stream stream, Encoding encoding, CancellationToken cancellationToken)
+		{
+			var ret = await ParseAsEnumerableAsync(stream, encoding, cancellationToken).ToListAsync(cancellationToken);
+			if (ret.Count == 0) throw new ArgumentException(BadFormatMsg);
+			return ret;
+		}
+
+		public IEnumerable<SubtitleModel> ParseAsEnumerable(Stream ssaStream, Encoding encoding)
+		{
 			StreamHelper.ThrowIfStreamIsNotSeekableOrReadable(ssaStream);
 			// seek the beginning of the stream
 			ssaStream.Position = 0;
 
-			// Create a StreamReader & configure it to leave the main stream open when disposing
-			using StreamReader reader = new StreamReader(ssaStream, encoding, true, 1024, true);
+			IEnumerable<SsaSubtitlePart> parts = GetParts(ssaStream, encoding).Peekable(out var partsAny);
+			if (!partsAny)
+				throw new ArgumentException(BadFormatMsg);
 
+			bool first = true;
+			foreach (SsaSubtitlePart part in parts)
+			{
+				yield return ParsePart(part, first);
+				first = false;
+			}
+		}
+
+		public async IAsyncEnumerable<SubtitleModel> ParseAsEnumerableAsync(Stream ssaStream, Encoding encoding, [EnumeratorCancellation] CancellationToken cancellationToken)
+		{
+			StreamHelper.ThrowIfStreamIsNotSeekableOrReadable(ssaStream);
+			// seek the beginning of the stream
+			ssaStream.Position = 0;
+
+			var parts = GetPartsAsync(ssaStream, encoding, cancellationToken);
+			var partsAny = await parts.PeekableAsync();
+			if (!partsAny)
+				throw new ArgumentException(BadFormatMsg);
+
+			bool first = true;
+			await foreach (SsaSubtitlePart part in parts.WithCancellation(cancellationToken))
+			{
+				yield return ParsePart(part, first);
+				first = false;
+			}
+		}
+
+		public IEnumerable<SsaSubtitlePart> GetParts(Stream stream, Encoding encoding)
+		{
+			using StreamReader reader = new StreamReader(stream, encoding, detectEncodingFromByteOrderMarks: true, 1024, true);
+			foreach (var part in GetSsaSubtitleParts(reader))
+			{
+				yield return part;
+			}
+		}
+
+		public async IAsyncEnumerable<SsaSubtitlePart> GetPartsAsync(Stream stream, Encoding encoding, [EnumeratorCancellation] CancellationToken cancellationToken = default)
+		{
+			using StreamReader reader = new StreamReader(stream, encoding, detectEncodingFromByteOrderMarks: true, 1024, true);
+			await foreach (var part in GetSsaSubtitlePartsAsync(reader, cancellationToken))
+			{
+				yield return part;
+			}
+		}
+
+		public SubtitleModel ParsePart(SsaSubtitlePart part, bool isFirstPart)
+		{
+			int start = ParserHelper.ParseTimeSpanLineAsMilliseconds(part.StartText);
+			int end = ParserHelper.ParseTimeSpanLineAsMilliseconds(part.EndText);
+
+			if (start > 0 && end > 0 && !string.IsNullOrEmpty(part.TextLine))
+			{
+				List<string> lines;
+				switch (part.WrapStyle)
+				{
+					case SsaWrapStyleHelper.Smart:
+					case SsaWrapStyleHelper.SmartWideLowerLine:
+					case SsaWrapStyleHelper.EndOfLine:
+						// according to the spec doc: 
+						// `\n` is ignored by SSA if smart-wrapping (and therefore smart with wider lower line) is enabled
+						// end-of-line word wrapping: only `\N` breaks
+						lines = part.TextLine.Split(@"\N").ToList();
+						break;
+					case SsaWrapStyleHelper.None:
+						// the default value of the variable is None, which breaks on either `\n` or `\N`
+
+						// according to the spec doc: 
+						// no word wrapping: `\n` `\N` both breaks
+						lines = Regex.Split(part.TextLine, @"(?:\\n)|(?:\\N)").ToList();
+						break;
+					default:
+						throw new ArgumentOutOfRangeException();
+				}
+
+				// trim any spaces from the start of a line (happens when a subtitler includes a space after a newline char ie `this is\N two lines` instead of `this is\Ntwo lines`)
+				// this doesn't actually matter for the SSA/ASS format, however if you were to want to convert from SSA/ASS to a format like SRT, it could lead to spaces preceding the second line, which looks funny 
+				lines = lines.Select(line => line.TrimStart()).ToList();
+
+				return new SubtitleModel()
+				{
+					StartTime = start,
+					EndTime = end,
+					// strip formatting by removing anything within curly braces, this will not remove duplicate content however,
+					// which can happen when working with signs for example
+					Lines = lines.Select(subtitleLine => Regex.Replace(subtitleLine, @"\{.*?\}", string.Empty)).ToList()
+				};
+			}
+
+			// Return an empty subtitle if parsing failed
+			return new SubtitleModel()
+			{
+				StartTime = start,
+				EndTime = end,
+				Lines = new List<string>()
+			};
+		}
+
+		/// <summary>
+		/// Enumerates the subtitle parts in an SSA file.
+		/// </summary>
+		/// <param name="reader">The textreader associated with the SSA file</param>
+		/// <returns>An IEnumerable of SsaSubtitlePart objects</returns>
+		private static IEnumerable<SsaSubtitlePart> GetSsaSubtitleParts(TextReader reader)
+		{
 			// default wrap style to none if the header section doesn't contain a wrap style definition
 			// (very possible since it wasn't present in SSA, only ASS) 
 			SsaWrapStyleHelper wrapStyle = SsaWrapStyleHelper.None;
@@ -90,69 +213,23 @@ namespace SubtitlesParserV2.Formats.Parsers
 
 					if (startIndexColumn > 0 && endIndexColumn > 0 && textIndexColumn > 0)
 					{
-						List<SubtitleModel> items = new List<SubtitleModel>();
-
 						line = reader.ReadLine();
 						while (!string.IsNullOrEmpty(line))
 						{
 							string[] columns = line.Split(SsaFormatConstantsHelper.SEPARATOR);
 							string startText = columns[startIndexColumn];
 							string endText = columns[endIndexColumn];
-
-
 							string textLine = string.Join(",", columns.Skip(textIndexColumn));
 
-							int start = ParserHelper.ParseTimeSpanLineAsMilliseconds(startText);
-							int end = ParserHelper.ParseTimeSpanLineAsMilliseconds(endText);
-
-							if (start > 0 && end > 0 && !string.IsNullOrEmpty(textLine))
+							yield return new SsaSubtitlePart
 							{
-								List<string> lines;
-								switch (wrapStyle)
-								{
-									case SsaWrapStyleHelper.Smart:
-									case SsaWrapStyleHelper.SmartWideLowerLine:
-									case SsaWrapStyleHelper.EndOfLine:
-										// according to the spec doc: 
-										// `\n` is ignored by SSA if smart-wrapping (and therefore smart with wider lower line) is enabled
-										// end-of-line word wrapping: only `\N` breaks
-										lines = textLine.Split(@"\N").ToList();
-										break;
-									case SsaWrapStyleHelper.None:
-										// the default value of the variable is None, which breaks on either `\n` or `\N`
+								StartText = startText,
+								EndText = endText,
+								TextLine = textLine,
+								WrapStyle = wrapStyle
+							};
 
-										// according to the spec doc: 
-										// no word wrapping: `\n` `\N` both breaks
-										lines = Regex.Split(textLine, @"(?:\\n)|(?:\\N)").ToList();
-										break;
-									default:
-										throw new ArgumentOutOfRangeException();
-								}
-
-								// trim any spaces from the start of a line (happens when a subtitler includes a space after a newline char ie `this is\N two lines` instead of `this is\Ntwo lines`)
-								// this doesn't actually matter for the SSA/ASS format, however if you were to want to convert from SSA/ASS to a format like SRT, it could lead to spaces preceding the second line, which looks funny 
-								lines = lines.Select(line => line.TrimStart()).ToList();
-
-								var item = new SubtitleModel()
-								{
-									StartTime = start,
-									EndTime = end,
-									// strip formatting by removing anything within curly braces, this will not remove duplicate content however,
-									// which can happen when working with signs for example
-									Lines = lines.Select(subtitleLine => Regex.Replace(subtitleLine, @"\{.*?\}", string.Empty)).ToList()
-								};
-								items.Add(item);
-							}
 							line = reader.ReadLine();
-						}
-
-						if (items.Count != 0)
-						{
-							return items;
-						}
-						else
-						{
-							throw new ArgumentException("Stream is not in a valid Ssa format");
 						}
 					}
 					else
@@ -165,8 +242,102 @@ namespace SubtitlesParserV2.Formats.Parsers
 					throw new ArgumentException($"The header line after the line '{line}' was null -> no need to continue parsing.");
 				}
 			}
-			else throw new ArgumentException($"Reached line ${line} on a total of #{lineNumber} lines, without finding Event section ({SsaFormatConstantsHelper.EVENT_LINE}). Aborted parsing.");
-
+			else
+			{
+				throw new ArgumentException($"Reached line ${line} on a total of #{lineNumber} lines, without finding Event section ({SsaFormatConstantsHelper.EVENT_LINE}). Aborted parsing.");
+			}
 		}
+
+		/// <summary>
+		/// Asynchronously enumerates the subtitle parts in an SSA file.
+		/// </summary>
+		/// <param name="reader">The textreader associated with the SSA file</param>
+		/// <param name="cancellationToken">Cancellation token</param>
+		/// <returns>An IAsyncEnumerable of SsaSubtitlePart objects</returns>
+		private static async IAsyncEnumerable<SsaSubtitlePart> GetSsaSubtitlePartsAsync(TextReader reader, [EnumeratorCancellation] CancellationToken cancellationToken = default)
+		{
+			// default wrap style to none if the header section doesn't contain a wrap style definition
+			// (very possible since it wasn't present in SSA, only ASS) 
+			SsaWrapStyleHelper wrapStyle = SsaWrapStyleHelper.None;
+
+			string? line = await reader.ReadLineAsync();
+			int lineNumber = 1;
+			// read the line until the [Events] section
+			while (line != null && line != SsaFormatConstantsHelper.EVENT_LINE)
+			{
+				cancellationToken.ThrowIfCancellationRequested();
+
+				if (line.StartsWith(SsaFormatConstantsHelper.WRAP_STYLE_PREFIX))
+				{
+					// get the wrap style
+					// the raw string is the second array item after splitting the line at `:` (which we know will be present since it's
+					// included in the `WRAP_STYLE_PREFIX` const), so trim the space off the beginning of that item, and parse that string into the enum 
+					wrapStyle = line.Split(':')[1].TrimStart().FromString();
+				}
+
+				line = await reader.ReadLineAsync();
+				lineNumber++;
+			}
+
+			if (line != null)
+			{
+				// We are at the event section
+				string? headerLine = await reader.ReadLineAsync();
+				if (!string.IsNullOrEmpty(headerLine))
+				{
+					List<string> columnHeaders = headerLine.Split(SsaFormatConstantsHelper.SEPARATOR).Select(head => head.Trim()).ToList();
+					int startIndexColumn = columnHeaders.IndexOf(SsaFormatConstantsHelper.START_COLUMN);
+					int endIndexColumn = columnHeaders.IndexOf(SsaFormatConstantsHelper.END_COLUMN);
+					int textIndexColumn = columnHeaders.IndexOf(SsaFormatConstantsHelper.TEXT_COLUMN);
+
+					if (startIndexColumn > 0 && endIndexColumn > 0 && textIndexColumn > 0)
+					{
+						line = await reader.ReadLineAsync();
+						while (!string.IsNullOrEmpty(line))
+						{
+							cancellationToken.ThrowIfCancellationRequested();
+
+							string[] columns = line.Split(SsaFormatConstantsHelper.SEPARATOR);
+							string startText = columns[startIndexColumn];
+							string endText = columns[endIndexColumn];
+							string textLine = string.Join(",", columns.Skip(textIndexColumn));
+
+							yield return new SsaSubtitlePart
+							{
+								StartText = startText,
+								EndText = endText,
+								TextLine = textLine,
+								WrapStyle = wrapStyle
+							};
+
+							line = await reader.ReadLineAsync();
+						}
+					}
+					else
+					{
+						throw new ArgumentException($"Couldn't find all the necessary columns headers ({SsaFormatConstantsHelper.START_COLUMN}, {SsaFormatConstantsHelper.END_COLUMN}, {SsaFormatConstantsHelper.TEXT_COLUMN}) in header line {headerLine}");
+					}
+				}
+				else
+				{
+					throw new ArgumentException($"The header line after the line '{line}' was null -> no need to continue parsing.");
+				}
+			}
+			else
+			{
+				throw new ArgumentException($"Reached line ${line} on a total of #{lineNumber} lines, without finding Event section ({SsaFormatConstantsHelper.EVENT_LINE}). Aborted parsing.");
+			}
+		}
+	}
+
+	/// <summary>
+	/// Represents a parsed SSA subtitle part before conversion to SubtitleModel
+	/// </summary>
+	internal class SsaSubtitlePart
+	{
+		public string StartText { get; set; } = string.Empty;
+		public string EndText { get; set; } = string.Empty;
+		public string TextLine { get; set; } = string.Empty;
+		public SsaWrapStyleHelper WrapStyle { get; set; }
 	}
 }

--- a/SubtitlesParserV2/Formats/Parsers/SsaParser.cs
+++ b/SubtitlesParserV2/Formats/Parsers/SsaParser.cs
@@ -89,8 +89,8 @@ namespace SubtitlesParserV2.Formats.Parsers
 			// seek the beginning of the stream
 			ssaStream.Position = 0;
 
-			var parts = GetPartsAsync(ssaStream, encoding, cancellationToken);
-			var partsAny = await parts.PeekableAsync();
+			var partsOld = GetPartsAsync(ssaStream, encoding, cancellationToken);
+			var (parts,partsAny) = await partsOld.PeekableAsync();
 			if (!partsAny)
 				throw new FormatException(BadFormatMsg);
 

--- a/SubtitlesParserV2/Formats/Parsers/SsaParser.cs
+++ b/SubtitlesParserV2/Formats/Parsers/SsaParser.cs
@@ -54,14 +54,14 @@ namespace SubtitlesParserV2.Formats.Parsers
 		public List<SubtitleModel> ParseStream(Stream ssaStream, Encoding encoding)
 		{
 			var ret = ParseStreamConsuming(ssaStream, encoding).ToList();
-			if (ret.Count == 0) throw new ArgumentException(BadFormatMsg);
+			if (ret.Count == 0) throw new FormatException(BadFormatMsg);
 			return ret;
 		}
 
 		public async Task<List<SubtitleModel>> ParseStreamAsync(Stream stream, Encoding encoding, CancellationToken cancellationToken)
 		{
 			var ret = await ParseStreamConsumingAsync(stream, encoding, cancellationToken).ToListAsync(cancellationToken);
-			if (ret.Count == 0) throw new ArgumentException(BadFormatMsg);
+			if (ret.Count == 0) throw new FormatException(BadFormatMsg);
 			return ret;
 		}
 
@@ -73,7 +73,7 @@ namespace SubtitlesParserV2.Formats.Parsers
 
 			IEnumerable<SsaSubtitlePart> parts = GetParts(ssaStream, encoding).Peekable(out var partsAny);
 			if (!partsAny)
-				throw new ArgumentException(BadFormatMsg);
+				throw new FormatException(BadFormatMsg);
 
 			bool first = true;
 			foreach (SsaSubtitlePart part in parts)
@@ -92,7 +92,7 @@ namespace SubtitlesParserV2.Formats.Parsers
 			var parts = GetPartsAsync(ssaStream, encoding, cancellationToken);
 			var partsAny = await parts.PeekableAsync();
 			if (!partsAny)
-				throw new ArgumentException(BadFormatMsg);
+				throw new FormatException(BadFormatMsg);
 
 			bool first = true;
 			await foreach (SsaSubtitlePart part in parts.WithCancellation(cancellationToken))

--- a/SubtitlesParserV2/Formats/Parsers/SsaParser.cs
+++ b/SubtitlesParserV2/Formats/Parsers/SsaParser.cs
@@ -53,19 +53,19 @@ namespace SubtitlesParserV2.Formats.Parsers
 
 		public List<SubtitleModel> ParseStream(Stream ssaStream, Encoding encoding)
 		{
-			var ret = ParseAsEnumerable(ssaStream, encoding).ToList();
+			var ret = ParseStreamConsuming(ssaStream, encoding).ToList();
 			if (ret.Count == 0) throw new ArgumentException(BadFormatMsg);
 			return ret;
 		}
 
 		public async Task<List<SubtitleModel>> ParseStreamAsync(Stream stream, Encoding encoding, CancellationToken cancellationToken)
 		{
-			var ret = await ParseAsEnumerableAsync(stream, encoding, cancellationToken).ToListAsync(cancellationToken);
+			var ret = await ParseStreamConsumingAsync(stream, encoding, cancellationToken).ToListAsync(cancellationToken);
 			if (ret.Count == 0) throw new ArgumentException(BadFormatMsg);
 			return ret;
 		}
 
-		public IEnumerable<SubtitleModel> ParseAsEnumerable(Stream ssaStream, Encoding encoding)
+		public IEnumerable<SubtitleModel> ParseStreamConsuming(Stream ssaStream, Encoding encoding)
 		{
 			StreamHelper.ThrowIfStreamIsNotSeekableOrReadable(ssaStream);
 			// seek the beginning of the stream
@@ -83,7 +83,7 @@ namespace SubtitlesParserV2.Formats.Parsers
 			}
 		}
 
-		public async IAsyncEnumerable<SubtitleModel> ParseAsEnumerableAsync(Stream ssaStream, Encoding encoding, [EnumeratorCancellation] CancellationToken cancellationToken)
+		public async IAsyncEnumerable<SubtitleModel> ParseStreamConsumingAsync(Stream ssaStream, Encoding encoding, [EnumeratorCancellation] CancellationToken cancellationToken)
 		{
 			StreamHelper.ThrowIfStreamIsNotSeekableOrReadable(ssaStream);
 			// seek the beginning of the stream

--- a/SubtitlesParserV2/Formats/Parsers/SubViewerParser.cs
+++ b/SubtitlesParserV2/Formats/Parsers/SubViewerParser.cs
@@ -49,19 +49,19 @@ namespace SubtitlesParserV2.Formats.Parsers
 
 		public List<SubtitleModel> ParseStream(Stream subStream, Encoding encoding)
 		{
-			var ret = ParseAsEnumerable(subStream, encoding).ToList();
+			var ret = ParseStreamConsuming(subStream, encoding).ToList();
 			if (ret.Count == 0) throw new ArgumentException(BadFormatMsg);
 			return ret;
 		}
 
 		public async Task<List<SubtitleModel>> ParseStreamAsync(Stream stream, Encoding encoding, CancellationToken cancellationToken)
 		{
-			var ret = await ParseAsEnumerableAsync(stream, encoding, cancellationToken).ToListAsync(cancellationToken);
+			var ret = await ParseStreamConsumingAsync(stream, encoding, cancellationToken).ToListAsync(cancellationToken);
 			if (ret.Count == 0) throw new ArgumentException(BadFormatMsg);
 			return ret;
 		}
 
-		public IEnumerable<SubtitleModel> ParseAsEnumerable(Stream subStream, Encoding encoding)
+		public IEnumerable<SubtitleModel> ParseStreamConsuming(Stream subStream, Encoding encoding)
 		{
 			StreamHelper.ThrowIfStreamIsNotSeekableOrReadable(subStream);
 			// seek the beginning of the stream
@@ -79,7 +79,7 @@ namespace SubtitlesParserV2.Formats.Parsers
 			}
 		}
 
-		public async IAsyncEnumerable<SubtitleModel> ParseAsEnumerableAsync(Stream subStream, Encoding encoding, [EnumeratorCancellation] CancellationToken cancellationToken)
+		public async IAsyncEnumerable<SubtitleModel> ParseStreamConsumingAsync(Stream subStream, Encoding encoding, [EnumeratorCancellation] CancellationToken cancellationToken)
 		{
 			StreamHelper.ThrowIfStreamIsNotSeekableOrReadable(subStream);
 			// seek the beginning of the stream

--- a/SubtitlesParserV2/Formats/Parsers/SubViewerParser.cs
+++ b/SubtitlesParserV2/Formats/Parsers/SubViewerParser.cs
@@ -50,14 +50,14 @@ namespace SubtitlesParserV2.Formats.Parsers
 		public List<SubtitleModel> ParseStream(Stream subStream, Encoding encoding)
 		{
 			var ret = ParseStreamConsuming(subStream, encoding).ToList();
-			if (ret.Count == 0) throw new ArgumentException(BadFormatMsg);
+			if (ret.Count == 0) throw new FormatException(BadFormatMsg);
 			return ret;
 		}
 
 		public async Task<List<SubtitleModel>> ParseStreamAsync(Stream stream, Encoding encoding, CancellationToken cancellationToken)
 		{
 			var ret = await ParseStreamConsumingAsync(stream, encoding, cancellationToken).ToListAsync(cancellationToken);
-			if (ret.Count == 0) throw new ArgumentException(BadFormatMsg);
+			if (ret.Count == 0) throw new FormatException(BadFormatMsg);
 			return ret;
 		}
 
@@ -69,7 +69,7 @@ namespace SubtitlesParserV2.Formats.Parsers
 
 			IEnumerable<SubViewerSubtitlePart> parts = GetParts(subStream, encoding).Peekable(out var partsAny);
 			if (!partsAny)
-				throw new ArgumentException(BadFormatMsg);
+				throw new FormatException(BadFormatMsg);
 
 			bool first = true;
 			foreach (SubViewerSubtitlePart part in parts)
@@ -88,7 +88,7 @@ namespace SubtitlesParserV2.Formats.Parsers
 			var parts = GetPartsAsync(subStream, encoding, cancellationToken);
 			var partsAny = await parts.PeekableAsync();
 			if (!partsAny)
-				throw new ArgumentException(BadFormatMsg);
+				throw new FormatException(BadFormatMsg);
 
 			bool first = true;
 			await foreach (SubViewerSubtitlePart part in parts.WithCancellation(cancellationToken))
@@ -224,7 +224,7 @@ namespace SubtitlesParserV2.Formats.Parsers
 			}
 			else
 			{
-				throw new ArgumentException("Stream is not in a valid SubViewer format");
+				throw new FormatException("Stream is not in a valid SubViewer format");
 			}
 		}
 
@@ -313,7 +313,7 @@ namespace SubtitlesParserV2.Formats.Parsers
 			}
 			else
 			{
-				throw new ArgumentException("Stream is not in a valid SubViewer format");
+				throw new FormatException("Stream is not in a valid SubViewer format");
 			}
 		}
 

--- a/SubtitlesParserV2/Formats/Parsers/SubViewerParser.cs
+++ b/SubtitlesParserV2/Formats/Parsers/SubViewerParser.cs
@@ -85,8 +85,8 @@ namespace SubtitlesParserV2.Formats.Parsers
 			// seek the beginning of the stream
 			subStream.Position = 0;
 
-			var parts = GetPartsAsync(subStream, encoding, cancellationToken);
-			var partsAny = await parts.PeekableAsync();
+			var partsOld = GetPartsAsync(subStream, encoding, cancellationToken);
+			var (parts,partsAny) = await partsOld.PeekableAsync();
 			if (!partsAny)
 				throw new FormatException(BadFormatMsg);
 
@@ -224,7 +224,7 @@ namespace SubtitlesParserV2.Formats.Parsers
 			}
 			else
 			{
-				throw new FormatException("Stream is not in a valid SubViewer format");
+				throw new ArgumentException("Stream is not in a valid SubViewer format");
 			}
 		}
 
@@ -313,7 +313,7 @@ namespace SubtitlesParserV2.Formats.Parsers
 			}
 			else
 			{
-				throw new FormatException("Stream is not in a valid SubViewer format");
+				throw new ArgumentException("Stream is not in a valid SubViewer format");
 			}
 		}
 

--- a/SubtitlesParserV2/Formats/Parsers/TmpParser.cs
+++ b/SubtitlesParserV2/Formats/Parsers/TmpParser.cs
@@ -30,19 +30,19 @@ namespace SubtitlesParserV2.Formats.Parsers
 
 		public List<SubtitleModel> ParseStream(Stream tmpStream, Encoding encoding)
 		{
-			var ret = ParseAsEnumerable(tmpStream, encoding).ToList();
+			var ret = ParseStreamConsuming(tmpStream, encoding).ToList();
 			if (ret.Count == 0) throw new ArgumentException(BadFormatMsg);
 			return ret;
 		}
 
 		public async Task<List<SubtitleModel>> ParseStreamAsync(Stream stream, Encoding encoding, CancellationToken cancellationToken)
 		{
-			var ret = await ParseAsEnumerableAsync(stream, encoding, cancellationToken).ToListAsync(cancellationToken);
+			var ret = await ParseStreamConsumingAsync(stream, encoding, cancellationToken).ToListAsync(cancellationToken);
 			if (ret.Count == 0) throw new ArgumentException(BadFormatMsg);
 			return ret;
 		}
 
-		public IEnumerable<SubtitleModel> ParseAsEnumerable(Stream tmpStream, Encoding encoding)
+		public IEnumerable<SubtitleModel> ParseStreamConsuming(Stream tmpStream, Encoding encoding)
 		{
 			StreamHelper.ThrowIfStreamIsNotSeekableOrReadable(tmpStream);
 			// seek the beginning of the stream
@@ -60,7 +60,7 @@ namespace SubtitlesParserV2.Formats.Parsers
 			}
 		}
 
-		public async IAsyncEnumerable<SubtitleModel> ParseAsEnumerableAsync(Stream tmpStream, Encoding encoding, [EnumeratorCancellation] CancellationToken cancellationToken)
+		public async IAsyncEnumerable<SubtitleModel> ParseStreamConsumingAsync(Stream tmpStream, Encoding encoding, [EnumeratorCancellation] CancellationToken cancellationToken)
 		{
 			StreamHelper.ThrowIfStreamIsNotSeekableOrReadable(tmpStream);
 			// seek the beginning of the stream

--- a/SubtitlesParserV2/Formats/Parsers/TmpParser.cs
+++ b/SubtitlesParserV2/Formats/Parsers/TmpParser.cs
@@ -31,14 +31,14 @@ namespace SubtitlesParserV2.Formats.Parsers
 		public List<SubtitleModel> ParseStream(Stream tmpStream, Encoding encoding)
 		{
 			var ret = ParseStreamConsuming(tmpStream, encoding).ToList();
-			if (ret.Count == 0) throw new ArgumentException(BadFormatMsg);
+			if (ret.Count == 0) throw new FormatException(BadFormatMsg);
 			return ret;
 		}
 
 		public async Task<List<SubtitleModel>> ParseStreamAsync(Stream stream, Encoding encoding, CancellationToken cancellationToken)
 		{
 			var ret = await ParseStreamConsumingAsync(stream, encoding, cancellationToken).ToListAsync(cancellationToken);
-			if (ret.Count == 0) throw new ArgumentException(BadFormatMsg);
+			if (ret.Count == 0) throw new FormatException(BadFormatMsg);
 			return ret;
 		}
 
@@ -50,7 +50,7 @@ namespace SubtitlesParserV2.Formats.Parsers
 
 			IEnumerable<TmpSubtitlePart> parts = GetParts(tmpStream, encoding).Peekable(out var partsAny);
 			if (!partsAny)
-				throw new ArgumentException(BadFormatMsg);
+				throw new FormatException(BadFormatMsg);
 
 			bool first = true;
 			foreach (TmpSubtitlePart part in parts)
@@ -69,7 +69,7 @@ namespace SubtitlesParserV2.Formats.Parsers
 			var parts = GetPartsAsync(tmpStream, encoding, cancellationToken);
 			var partsAny = await parts.PeekableAsync();
 			if (!partsAny)
-				throw new ArgumentException(BadFormatMsg);
+				throw new FormatException(BadFormatMsg);
 
 			bool first = true;
 			await foreach (TmpSubtitlePart part in parts.WithCancellation(cancellationToken))
@@ -119,7 +119,7 @@ namespace SubtitlesParserV2.Formats.Parsers
 			// (Since the nextLine start time is also the end time for the lastLine)
 			string? lastLine = reader.ReadLine();
 			if (lastLine == null)
-				throw new ArgumentException("Stream reached end of file on first reading attempt.");
+				throw new FormatException("Stream reached end of file on first reading attempt.");
 
 			// Loop until last line was processed (is null), then do a final loop
 			do
@@ -166,7 +166,7 @@ namespace SubtitlesParserV2.Formats.Parsers
 			// (Since the nextLine start time is also the end time for the lastLine)
 			string? lastLine = await reader.ReadLineAsync();
 			if (lastLine == null)
-				throw new ArgumentException("Stream reached end of file on first reading attempt.");
+				throw new FormatException("Stream reached end of file on first reading attempt.");
 
 			// Loop until last line was processed (is null), then do a final loop
 			do
@@ -222,7 +222,7 @@ namespace SubtitlesParserV2.Formats.Parsers
 			// Ensure they is at least 4 separations on the line
 			// NOTE: We could default to defining time to -1 when invalid, however due to the file having almost no unique feature,
 			// a invalid timestamp is the best way to detect that the current stream is not in TMP format and stop parsing early
-			if (parts.Length < 4) throw new ArgumentException("Stream line is not in a valid TMP format.");
+			if (parts.Length < 4) throw new FormatException("Stream line is not in a valid TMP format.");
 
 			int hours = 0;
 			int minutes = 0;
@@ -230,7 +230,7 @@ namespace SubtitlesParserV2.Formats.Parsers
 			// Parse time, throw error if it fail
 			if (!int.TryParse(parts[0], out hours) || !int.TryParse(parts[1], out minutes) || !int.TryParse(parts[2], out seconds))
 			{
-				throw new ArgumentException("Stream line has invalid characters at positions used for time. Stream is not a valid TMP format.");
+				throw new FormatException("Stream line has invalid characters at positions used for time. Stream is not a valid TMP format.");
 			}
 			// Return time in MS along with line content
 			return ((int)new TimeSpan(hours, minutes, seconds).TotalMilliseconds, parts[3].Split('|').Select(line => line.Trim()).ToList());

--- a/SubtitlesParserV2/Formats/Parsers/TmpParser.cs
+++ b/SubtitlesParserV2/Formats/Parsers/TmpParser.cs
@@ -66,8 +66,8 @@ namespace SubtitlesParserV2.Formats.Parsers
 			// seek the beginning of the stream
 			tmpStream.Position = 0;
 
-			var parts = GetPartsAsync(tmpStream, encoding, cancellationToken);
-			var partsAny = await parts.PeekableAsync();
+			var partsOld = GetPartsAsync(tmpStream, encoding, cancellationToken);
+			var (parts,partsAny) = await partsOld.PeekableAsync();
 			if (!partsAny)
 				throw new FormatException(BadFormatMsg);
 
@@ -119,7 +119,7 @@ namespace SubtitlesParserV2.Formats.Parsers
 			// (Since the nextLine start time is also the end time for the lastLine)
 			string? lastLine = reader.ReadLine();
 			if (lastLine == null)
-				throw new FormatException("Stream reached end of file on first reading attempt.");
+				throw new ArgumentException("Stream reached end of file on first reading attempt.");
 
 			// Loop until last line was processed (is null), then do a final loop
 			do
@@ -166,7 +166,7 @@ namespace SubtitlesParserV2.Formats.Parsers
 			// (Since the nextLine start time is also the end time for the lastLine)
 			string? lastLine = await reader.ReadLineAsync();
 			if (lastLine == null)
-				throw new FormatException("Stream reached end of file on first reading attempt.");
+				throw new ArgumentException("Stream reached end of file on first reading attempt.");
 
 			// Loop until last line was processed (is null), then do a final loop
 			do
@@ -222,7 +222,7 @@ namespace SubtitlesParserV2.Formats.Parsers
 			// Ensure they is at least 4 separations on the line
 			// NOTE: We could default to defining time to -1 when invalid, however due to the file having almost no unique feature,
 			// a invalid timestamp is the best way to detect that the current stream is not in TMP format and stop parsing early
-			if (parts.Length < 4) throw new FormatException("Stream line is not in a valid TMP format.");
+			if (parts.Length < 4) throw new ArgumentException("Stream line is not in a valid TMP format.");
 
 			int hours = 0;
 			int minutes = 0;
@@ -230,7 +230,7 @@ namespace SubtitlesParserV2.Formats.Parsers
 			// Parse time, throw error if it fail
 			if (!int.TryParse(parts[0], out hours) || !int.TryParse(parts[1], out minutes) || !int.TryParse(parts[2], out seconds))
 			{
-				throw new FormatException("Stream line has invalid characters at positions used for time. Stream is not a valid TMP format.");
+				throw new ArgumentException("Stream line has invalid characters at positions used for time. Stream is not a valid TMP format.");
 			}
 			// Return time in MS along with line content
 			return ((int)new TimeSpan(hours, minutes, seconds).TotalMilliseconds, parts[3].Split('|').Select(line => line.Trim()).ToList());

--- a/SubtitlesParserV2/Formats/Parsers/TtmlParser.cs
+++ b/SubtitlesParserV2/Formats/Parsers/TtmlParser.cs
@@ -3,6 +3,7 @@ using System.Buffers.Text;
 using System.Collections.Generic;
 using System.Globalization;
 using System.IO;
+using System.Linq;
 using System.Runtime.CompilerServices;
 using System.Text;
 using System.Text.RegularExpressions;
@@ -39,19 +40,19 @@ namespace SubtitlesParserV2.Formats.Parsers
 
 		public List<SubtitleModel> ParseStream(Stream xmlStream, Encoding encoding)
 		{
-			var ret = ParseAsEnumerable(xmlStream, encoding).ToList();
+			var ret = ParseStreamConsuming(xmlStream, encoding).ToList();
 			if (ret.Count == 0) throw new ArgumentException(BadFormatMsg);
 			return ret;
 		}
 
 		public async Task<List<SubtitleModel>> ParseStreamAsync(Stream stream, Encoding encoding, CancellationToken cancellationToken)
 		{
-			var ret = await ParseAsEnumerableAsync(stream, encoding, cancellationToken).ToListAsync(cancellationToken);
+			var ret = await ParseStreamConsumingAsync(stream, encoding, cancellationToken).ToListAsync(cancellationToken);
 			if (ret.Count == 0) throw new ArgumentException(BadFormatMsg);
 			return ret;
 		}
 
-		public IEnumerable<SubtitleModel> ParseAsEnumerable(Stream xmlStream, Encoding encoding)
+		public IEnumerable<SubtitleModel> ParseStreamConsuming(Stream xmlStream, Encoding encoding)
 		{
 			StreamHelper.ThrowIfStreamIsNotSeekableOrReadable(xmlStream);
 			// seek the beginning of the stream
@@ -69,7 +70,7 @@ namespace SubtitlesParserV2.Formats.Parsers
 			}
 		}
 
-		public async IAsyncEnumerable<SubtitleModel> ParseAsEnumerableAsync(Stream xmlStream, Encoding encoding, [EnumeratorCancellation] CancellationToken cancellationToken)
+		public async IAsyncEnumerable<SubtitleModel> ParseStreamConsumingAsync(Stream xmlStream, Encoding encoding, [EnumeratorCancellation] CancellationToken cancellationToken)
 		{
 			StreamHelper.ThrowIfStreamIsNotSeekableOrReadable(xmlStream);
 			// seek the beginning of the stream

--- a/SubtitlesParserV2/Formats/Parsers/TtmlParser.cs
+++ b/SubtitlesParserV2/Formats/Parsers/TtmlParser.cs
@@ -76,8 +76,8 @@ namespace SubtitlesParserV2.Formats.Parsers
 			// seek the beginning of the stream
 			xmlStream.Position = 0;
 
-			var parts = GetPartsAsync(xmlStream, encoding, cancellationToken);
-			var partsAny = await parts.PeekableAsync();
+			var partsOld = GetPartsAsync(xmlStream, encoding, cancellationToken);
+			var (parts,partsAny) = await partsOld.PeekableAsync();
 			if (!partsAny)
 				throw new FormatException(BadFormatMsg);
 

--- a/SubtitlesParserV2/Formats/Parsers/TtmlParser.cs
+++ b/SubtitlesParserV2/Formats/Parsers/TtmlParser.cs
@@ -41,14 +41,14 @@ namespace SubtitlesParserV2.Formats.Parsers
 		public List<SubtitleModel> ParseStream(Stream xmlStream, Encoding encoding)
 		{
 			var ret = ParseStreamConsuming(xmlStream, encoding).ToList();
-			if (ret.Count == 0) throw new ArgumentException(BadFormatMsg);
+			if (ret.Count == 0) throw new FormatException(BadFormatMsg);
 			return ret;
 		}
 
 		public async Task<List<SubtitleModel>> ParseStreamAsync(Stream stream, Encoding encoding, CancellationToken cancellationToken)
 		{
 			var ret = await ParseStreamConsumingAsync(stream, encoding, cancellationToken).ToListAsync(cancellationToken);
-			if (ret.Count == 0) throw new ArgumentException(BadFormatMsg);
+			if (ret.Count == 0) throw new FormatException(BadFormatMsg);
 			return ret;
 		}
 
@@ -60,7 +60,7 @@ namespace SubtitlesParserV2.Formats.Parsers
 
 			IEnumerable<TtmlSubtitlePart> parts = GetParts(xmlStream, encoding).Peekable(out var partsAny);
 			if (!partsAny)
-				throw new ArgumentException(BadFormatMsg);
+				throw new FormatException(BadFormatMsg);
 
 			bool first = true;
 			foreach (TtmlSubtitlePart part in parts)
@@ -79,7 +79,7 @@ namespace SubtitlesParserV2.Formats.Parsers
 			var parts = GetPartsAsync(xmlStream, encoding, cancellationToken);
 			var partsAny = await parts.PeekableAsync();
 			if (!partsAny)
-				throw new ArgumentException(BadFormatMsg);
+				throw new FormatException(BadFormatMsg);
 
 			bool first = true;
 			await foreach (TtmlSubtitlePart part in parts.WithCancellation(cancellationToken))

--- a/SubtitlesParserV2/Formats/Parsers/UsfParser.cs
+++ b/SubtitlesParserV2/Formats/Parsers/UsfParser.cs
@@ -1,10 +1,14 @@
-﻿using SubtitlesParserV2.Helpers;
+using SubtitlesParserV2.Helpers;
 using SubtitlesParserV2.Models;
 using System;
 using System.Collections.Generic;
 using System.IO;
+using System.Linq;
+using System.Runtime.CompilerServices;
 using System.Text;
 using System.Text.RegularExpressions;
+using System.Threading;
+using System.Threading.Tasks;
 using System.Xml;
 
 namespace SubtitlesParserV2.Formats.Parsers
@@ -18,80 +22,204 @@ namespace SubtitlesParserV2.Formats.Parsers
 	/// https://www.titlevision.dk/usf-file-format/
 	/// https://subtitld.org/en/development/usf
 	/// -->
-	internal class UsfParser : ISubtitlesParser
+	internal class UsfParser : ISubtitlesParser<UsfSubtitlePart>
 	{
 		// hh:mm:ss:mmm
 		private static readonly Regex BaseTimestampFormat = new Regex(@"^(?:(?<hours>\d+)):(?<minutes>[0-5]\d):(?<seconds>[0-5]\d)(?:\.(?<milliseconds>\d+))?$", RegexOptions.Compiled);
 		// ss[.mmm]
 		private static readonly Regex ShortTimestampFormat = new Regex(@"^(?<seconds>\d+)(?:\.(?<millisecond>\d+))?$", RegexOptions.Compiled);
 
+		private const string BadFormatMsg = "Stream is not in a valid USF format, or represents empty subtitles";
+
 		public List<SubtitleModel> ParseStream(Stream xmlStream, Encoding encoding)
+		{
+			var ret = ParseAsEnumerable(xmlStream, encoding).ToList();
+			if (ret.Count == 0) throw new ArgumentException(BadFormatMsg);
+			return ret;
+		}
+
+		public async Task<List<SubtitleModel>> ParseStreamAsync(Stream stream, Encoding encoding, CancellationToken cancellationToken)
+		{
+			var ret = await ParseAsEnumerableAsync(stream, encoding, cancellationToken).ToListAsync(cancellationToken);
+			if (ret.Count == 0) throw new ArgumentException(BadFormatMsg);
+			return ret;
+		}
+
+		public IEnumerable<SubtitleModel> ParseAsEnumerable(Stream xmlStream, Encoding encoding)
 		{
 			StreamHelper.ThrowIfStreamIsNotSeekableOrReadable(xmlStream);
 			// seek the beginning of the stream
 			xmlStream.Position = 0;
-			List<SubtitleModel> items = new List<SubtitleModel>();
 
-			// Read the xml stream line by line
-			using XmlReader reader = XmlReader.Create(xmlStream, new XmlReaderSettings { IgnoreWhitespace = true, IgnoreComments = true });
+			IEnumerable<UsfSubtitlePart> parts = GetParts(xmlStream, encoding).Peekable(out var partsAny);
+			if (!partsAny)
+				throw new ArgumentException(BadFormatMsg);
+
+			bool first = true;
+			foreach (UsfSubtitlePart part in parts)
+			{
+				yield return ParsePart(part, first);
+				first = false;
+			}
+		}
+
+		public async IAsyncEnumerable<SubtitleModel> ParseAsEnumerableAsync(Stream xmlStream, Encoding encoding, [EnumeratorCancellation] CancellationToken cancellationToken)
+		{
+			StreamHelper.ThrowIfStreamIsNotSeekableOrReadable(xmlStream);
+			// seek the beginning of the stream
+			xmlStream.Position = 0;
+
+			var parts = GetPartsAsync(xmlStream, encoding, cancellationToken);
+			var partsAny = await parts.PeekableAsync();
+			if (!partsAny)
+				throw new ArgumentException(BadFormatMsg);
+
+			bool first = true;
+			await foreach (UsfSubtitlePart part in parts.WithCancellation(cancellationToken))
+			{
+				yield return ParsePart(part, first);
+				first = false;
+			}
+		}
+
+		public IEnumerable<UsfSubtitlePart> GetParts(Stream stream, Encoding encoding)
+		{
+			using XmlReader xmlReader = XmlReader.Create(stream, new XmlReaderSettings { IgnoreWhitespace = true, IgnoreComments = true });
+			foreach (var part in GetPartsFromXmlReader(xmlReader))
+			{
+				yield return part;
+			}
+		}
+
+		public async IAsyncEnumerable<UsfSubtitlePart> GetPartsAsync(Stream stream, Encoding encoding, [EnumeratorCancellation] CancellationToken cancellationToken = default)
+		{
+			using XmlReader xmlReader = XmlReader.Create(stream, new XmlReaderSettings { IgnoreWhitespace = true, IgnoreComments = true, Async = true });
+			await foreach (var part in GetPartsFromXmlReaderAsync(xmlReader, cancellationToken))
+			{
+				yield return part;
+			}
+		}
+
+		private IEnumerable<UsfSubtitlePart> GetPartsFromXmlReader(XmlReader reader)
+		{
+			bool rootElementValidated = false;
 
 			while (reader.Read())
 			{
 				if (reader.NodeType == XmlNodeType.Element)
 				{
 					// Ensure the root element matches the definition of USF files
-					if (reader.Depth == 0 && !reader.Name.Equals("USFSubtitles", StringComparison.OrdinalIgnoreCase))
+					if (reader.Depth == 0 && !rootElementValidated)
 					{
-						throw new ArgumentException("Stream is not in a valid USF format (root element is not USFSubtitles)");
+						if (!reader.Name.Equals("USFSubtitles", StringComparison.OrdinalIgnoreCase))
+						{
+							throw new ArgumentException("Stream is not in a valid USF format (root element is not USFSubtitles)");
+						}
+						rootElementValidated = true;
 					}
-
 
 					// Parse the <subtitle> element
 					if (reader.LocalName == "subtitle")
 					{
-						// Parse time
 						string startString = reader.GetAttribute("start") ?? string.Empty;
-						int startMs = ParseTimecode(startString);
-
 						string endString = reader.GetAttribute("stop") ?? string.Empty;
-						int endMs = startMs; // Default value if not found is end time same as start time
+						string durString = reader.GetAttribute("duration") ?? string.Empty;
 
-						// If no end string, try to look for a duration string
-						if (string.IsNullOrEmpty(endString))
-						{
-							// Sometime time has start and duration instead of start and end time
-							string durString = reader.GetAttribute("duration") ?? string.Empty;
-							if (!string.IsNullOrEmpty(durString))
-							{
-								// Duration in ms + start time in ms = end time in ms
-								endMs = ParseTimecode(durString) + startMs;
-							}
-						}
-						else endMs = ParseTimecode(endString);
-
-
-
-						// Parse subtitle text
 						List<string> textLines = ParserHelper.XmlReadCurrentElementInnerText(reader);
-						if (textLines.Count >= 1)
+
+						yield return new UsfSubtitlePart
 						{
-							items.Add(new SubtitleModel()
-							{
-								StartTime = startMs,
-								EndTime = endMs,
-								Lines = textLines
-							});
-						}
+							StartAttribute = startString,
+							EndAttribute = endString,
+							DurationAttribute = durString,
+							TextLines = textLines
+						};
 					}
 				}
 			}
+		}
 
-			if (items.Count >= 1)
+		private async IAsyncEnumerable<UsfSubtitlePart> GetPartsFromXmlReaderAsync(XmlReader reader, [EnumeratorCancellation] CancellationToken cancellationToken = default)
+		{
+			bool rootElementValidated = false;
+
+			while (await reader.ReadAsync())
 			{
-				return items;
+				cancellationToken.ThrowIfCancellationRequested();
+
+				if (reader.NodeType == XmlNodeType.Element)
+				{
+					// Ensure the root element matches the definition of USF files
+					if (reader.Depth == 0 && !rootElementValidated)
+					{
+						if (!reader.Name.Equals("USFSubtitles", StringComparison.OrdinalIgnoreCase))
+						{
+							throw new ArgumentException("Stream is not in a valid USF format (root element is not USFSubtitles)");
+						}
+						rootElementValidated = true;
+					}
+
+					// Parse the <subtitle> element
+					if (reader.LocalName == "subtitle")
+					{
+						string startString = reader.GetAttribute("start") ?? string.Empty;
+						string endString = reader.GetAttribute("stop") ?? string.Empty;
+						string durString = reader.GetAttribute("duration") ?? string.Empty;
+
+						List<string> textLines = ParserHelper.XmlReadCurrentElementInnerText(reader);
+
+						yield return new UsfSubtitlePart
+						{
+							StartAttribute = startString,
+							EndAttribute = endString,
+							DurationAttribute = durString,
+							TextLines = textLines
+						};
+					}
+				}
 			}
-			throw new ArgumentException("Stream is not in a valid TTML format, or represents empty subtitles");
-			
+		}
+
+		public SubtitleModel ParsePart(UsfSubtitlePart part, bool isFirstPart)
+		{
+			// Parse time
+			int startMs = ParseTimecode(part.StartAttribute);
+			int endMs = startMs; // Default value if not found is end time same as start time
+
+			// If no end string, try to look for a duration string
+			if (string.IsNullOrEmpty(part.EndAttribute))
+			{
+				// Sometime time has start and duration instead of start and end time
+				if (!string.IsNullOrEmpty(part.DurationAttribute))
+				{
+					// Duration in ms + start time in ms = end time in ms
+					endMs = ParseTimecode(part.DurationAttribute) + startMs;
+				}
+			}
+			else
+			{
+				endMs = ParseTimecode(part.EndAttribute);
+			}
+
+			// Parse subtitle text
+			List<string> textLines = part.TextLines;
+			if (textLines.Count >= 1)
+			{
+				return new SubtitleModel()
+				{
+					StartTime = startMs,
+					EndTime = endMs,
+					Lines = textLines
+				};
+			}
+
+			// Return an empty subtitle if no text lines
+			return new SubtitleModel()
+			{
+				StartTime = startMs,
+				EndTime = endMs,
+				Lines = new List<string>()
+			};
 		}
 
 		/// <summary>
@@ -144,5 +272,16 @@ namespace SubtitlesParserV2.Formats.Parsers
 
 			return -1;
 		}
+	}
+
+	/// <summary>
+	/// Represents a parsed USF subtitle part before conversion to SubtitleModel
+	/// </summary>
+	internal class UsfSubtitlePart
+	{
+		public string StartAttribute { get; set; } = string.Empty;
+		public string EndAttribute { get; set; } = string.Empty;
+		public string DurationAttribute { get; set; } = string.Empty;
+		public List<string> TextLines { get; set; } = new List<string>();
 	}
 }

--- a/SubtitlesParserV2/Formats/Parsers/UsfParser.cs
+++ b/SubtitlesParserV2/Formats/Parsers/UsfParser.cs
@@ -34,14 +34,14 @@ namespace SubtitlesParserV2.Formats.Parsers
 		public List<SubtitleModel> ParseStream(Stream xmlStream, Encoding encoding)
 		{
 			var ret = ParseStreamConsuming(xmlStream, encoding).ToList();
-			if (ret.Count == 0) throw new ArgumentException(BadFormatMsg);
+			if (ret.Count == 0) throw new FormatException(BadFormatMsg);
 			return ret;
 		}
 
 		public async Task<List<SubtitleModel>> ParseStreamAsync(Stream stream, Encoding encoding, CancellationToken cancellationToken)
 		{
 			var ret = await ParseStreamConsumingAsync(stream, encoding, cancellationToken).ToListAsync(cancellationToken);
-			if (ret.Count == 0) throw new ArgumentException(BadFormatMsg);
+			if (ret.Count == 0) throw new FormatException(BadFormatMsg);
 			return ret;
 		}
 
@@ -53,7 +53,7 @@ namespace SubtitlesParserV2.Formats.Parsers
 
 			IEnumerable<UsfSubtitlePart> parts = GetParts(xmlStream, encoding).Peekable(out var partsAny);
 			if (!partsAny)
-				throw new ArgumentException(BadFormatMsg);
+				throw new FormatException(BadFormatMsg);
 
 			bool first = true;
 			foreach (UsfSubtitlePart part in parts)
@@ -72,7 +72,7 @@ namespace SubtitlesParserV2.Formats.Parsers
 			var parts = GetPartsAsync(xmlStream, encoding, cancellationToken);
 			var partsAny = await parts.PeekableAsync();
 			if (!partsAny)
-				throw new ArgumentException(BadFormatMsg);
+				throw new FormatException(BadFormatMsg);
 
 			bool first = true;
 			await foreach (UsfSubtitlePart part in parts.WithCancellation(cancellationToken))
@@ -113,7 +113,7 @@ namespace SubtitlesParserV2.Formats.Parsers
 					{
 						if (!reader.Name.Equals("USFSubtitles", StringComparison.OrdinalIgnoreCase))
 						{
-							throw new ArgumentException("Stream is not in a valid USF format (root element is not USFSubtitles)");
+							throw new FormatException("Stream is not in a valid USF format (root element is not USFSubtitles)");
 						}
 						rootElementValidated = true;
 					}
@@ -154,7 +154,7 @@ namespace SubtitlesParserV2.Formats.Parsers
 					{
 						if (!reader.Name.Equals("USFSubtitles", StringComparison.OrdinalIgnoreCase))
 						{
-							throw new ArgumentException("Stream is not in a valid USF format (root element is not USFSubtitles)");
+							throw new FormatException("Stream is not in a valid USF format (root element is not USFSubtitles)");
 						}
 						rootElementValidated = true;
 					}

--- a/SubtitlesParserV2/Formats/Parsers/UsfParser.cs
+++ b/SubtitlesParserV2/Formats/Parsers/UsfParser.cs
@@ -33,19 +33,19 @@ namespace SubtitlesParserV2.Formats.Parsers
 
 		public List<SubtitleModel> ParseStream(Stream xmlStream, Encoding encoding)
 		{
-			var ret = ParseAsEnumerable(xmlStream, encoding).ToList();
+			var ret = ParseStreamConsuming(xmlStream, encoding).ToList();
 			if (ret.Count == 0) throw new ArgumentException(BadFormatMsg);
 			return ret;
 		}
 
 		public async Task<List<SubtitleModel>> ParseStreamAsync(Stream stream, Encoding encoding, CancellationToken cancellationToken)
 		{
-			var ret = await ParseAsEnumerableAsync(stream, encoding, cancellationToken).ToListAsync(cancellationToken);
+			var ret = await ParseStreamConsumingAsync(stream, encoding, cancellationToken).ToListAsync(cancellationToken);
 			if (ret.Count == 0) throw new ArgumentException(BadFormatMsg);
 			return ret;
 		}
 
-		public IEnumerable<SubtitleModel> ParseAsEnumerable(Stream xmlStream, Encoding encoding)
+		public IEnumerable<SubtitleModel> ParseStreamConsuming(Stream xmlStream, Encoding encoding)
 		{
 			StreamHelper.ThrowIfStreamIsNotSeekableOrReadable(xmlStream);
 			// seek the beginning of the stream
@@ -63,7 +63,7 @@ namespace SubtitlesParserV2.Formats.Parsers
 			}
 		}
 
-		public async IAsyncEnumerable<SubtitleModel> ParseAsEnumerableAsync(Stream xmlStream, Encoding encoding, [EnumeratorCancellation] CancellationToken cancellationToken)
+		public async IAsyncEnumerable<SubtitleModel> ParseStreamConsumingAsync(Stream xmlStream, Encoding encoding, [EnumeratorCancellation] CancellationToken cancellationToken)
 		{
 			StreamHelper.ThrowIfStreamIsNotSeekableOrReadable(xmlStream);
 			// seek the beginning of the stream

--- a/SubtitlesParserV2/Formats/Parsers/UsfParser.cs
+++ b/SubtitlesParserV2/Formats/Parsers/UsfParser.cs
@@ -69,8 +69,8 @@ namespace SubtitlesParserV2.Formats.Parsers
 			// seek the beginning of the stream
 			xmlStream.Position = 0;
 
-			var parts = GetPartsAsync(xmlStream, encoding, cancellationToken);
-			var partsAny = await parts.PeekableAsync();
+			var partsOld = GetPartsAsync(xmlStream, encoding, cancellationToken);
+			var (parts,partsAny) = await partsOld.PeekableAsync();
 			if (!partsAny)
 				throw new FormatException(BadFormatMsg);
 
@@ -113,7 +113,7 @@ namespace SubtitlesParserV2.Formats.Parsers
 					{
 						if (!reader.Name.Equals("USFSubtitles", StringComparison.OrdinalIgnoreCase))
 						{
-							throw new FormatException("Stream is not in a valid USF format (root element is not USFSubtitles)");
+							throw new ArgumentException("Stream is not in a valid USF format (root element is not USFSubtitles)");
 						}
 						rootElementValidated = true;
 					}
@@ -154,7 +154,7 @@ namespace SubtitlesParserV2.Formats.Parsers
 					{
 						if (!reader.Name.Equals("USFSubtitles", StringComparison.OrdinalIgnoreCase))
 						{
-							throw new FormatException("Stream is not in a valid USF format (root element is not USFSubtitles)");
+							throw new ArgumentException("Stream is not in a valid USF format (root element is not USFSubtitles)");
 						}
 						rootElementValidated = true;
 					}

--- a/SubtitlesParserV2/Formats/Parsers/VttParser.cs
+++ b/SubtitlesParserV2/Formats/Parsers/VttParser.cs
@@ -73,8 +73,11 @@ namespace SubtitlesParserV2.Formats.Parsers
 			bool first = true;
 			foreach (string part in parts)
 			{
-				yield return ParsePart(part, first);
+				var ret =  ParsePart(part, first);
 				first = false;
+				if(ret.Equals(SubtitleModel.Default))
+					continue;
+				yield return ret;
 			}
 		}
 
@@ -92,8 +95,11 @@ namespace SubtitlesParserV2.Formats.Parsers
 			bool first = true;
 			await foreach (string part in parts.WithCancellation(cancellationToken))
 			{
-				yield return ParsePart(part, first);
+				var ret =  ParsePart(part, first);
 				first = false;
+				if(ret.Equals(SubtitleModel.Default))
+					continue;
+				yield return ret;
 			}
 		}
 
@@ -123,13 +129,7 @@ namespace SubtitlesParserV2.Formats.Parsers
 				if (part.Equals("WEBVTT", StringComparison.InvariantCultureIgnoreCase))
 				{
 					// Return an empty subtitle for the header
-					return null;
-					// return new SubtitleModel()
-					// {
-					// 	StartTime = -1,
-					// 	EndTime = -1,
-					// 	Lines = new List<string>()
-					// };
+					return SubtitleModel.Default;
 				}
 				else
 				{
@@ -185,7 +185,6 @@ namespace SubtitlesParserV2.Formats.Parsers
 		{
 			string? line = reader.ReadLine(); // Read first line
 			StringBuilder sb = new StringBuilder();
-
 			while (line != null)
 			{
 				// Verify if it's the end of the current part (new empty line)

--- a/SubtitlesParserV2/Formats/Parsers/VttParser.cs
+++ b/SubtitlesParserV2/Formats/Parsers/VttParser.cs
@@ -48,19 +48,19 @@ namespace SubtitlesParserV2.Formats.Parsers
 
 		public List<SubtitleModel> ParseStream(Stream vttStream, Encoding encoding)
 		{
-			var ret = ParseAsEnumerable(vttStream, encoding).ToList();
+			var ret = ParseStreamConsuming(vttStream, encoding).ToList();
 			if (ret.Count == 0) throw new ArgumentException(BadFormatMsg);
 			return ret;
 		}
 
 		public async Task<List<SubtitleModel>> ParseStreamAsync(Stream stream, Encoding encoding, CancellationToken cancellationToken)
 		{
-			var ret = await ParseAsEnumerableAsync(stream, encoding, cancellationToken).ToListAsync(cancellationToken);
+			var ret = await ParseStreamConsumingAsync(stream, encoding, cancellationToken).ToListAsync(cancellationToken);
 			if (ret.Count == 0) throw new ArgumentException(BadFormatMsg);
 			return ret;
 		}
 
-		public IEnumerable<SubtitleModel> ParseAsEnumerable(Stream vttStream, Encoding encoding)
+		public IEnumerable<SubtitleModel> ParseStreamConsuming(Stream vttStream, Encoding encoding)
 		{
 			StreamHelper.ThrowIfStreamIsNotSeekableOrReadable(vttStream);
 			// seek the beginning of the stream
@@ -78,7 +78,7 @@ namespace SubtitlesParserV2.Formats.Parsers
 			}
 		}
 
-		public async IAsyncEnumerable<SubtitleModel> ParseAsEnumerableAsync(Stream vttStream, Encoding encoding, [EnumeratorCancellation] CancellationToken cancellationToken)
+		public async IAsyncEnumerable<SubtitleModel> ParseStreamConsumingAsync(Stream vttStream, Encoding encoding, [EnumeratorCancellation] CancellationToken cancellationToken)
 		{
 			StreamHelper.ThrowIfStreamIsNotSeekableOrReadable(vttStream);
 			// seek the beginning of the stream

--- a/SubtitlesParserV2/Formats/Parsers/VttParser.cs
+++ b/SubtitlesParserV2/Formats/Parsers/VttParser.cs
@@ -84,8 +84,8 @@ namespace SubtitlesParserV2.Formats.Parsers
 			// seek the beginning of the stream
 			vttStream.Position = 0;
 
-			var parts = GetPartsAsync(vttStream, encoding, cancellationToken);
-			var partsAny = await parts.PeekableAsync();
+			var partsOld = GetPartsAsync(vttStream, encoding, cancellationToken);
+			var (parts, partsAny) = await partsOld.PeekableAsync();
 			if (!partsAny)
 				throw new FormatException(BadFormatMsg);
 
@@ -123,12 +123,13 @@ namespace SubtitlesParserV2.Formats.Parsers
 				if (part.Equals("WEBVTT", StringComparison.InvariantCultureIgnoreCase))
 				{
 					// Return an empty subtitle for the header
-					return new SubtitleModel()
-					{
-						StartTime = -1,
-						EndTime = -1,
-						Lines = new List<string>()
-					};
+					return null;
+					// return new SubtitleModel()
+					// {
+					// 	StartTime = -1,
+					// 	EndTime = -1,
+					// 	Lines = new List<string>()
+					// };
 				}
 				else
 				{

--- a/SubtitlesParserV2/Formats/Parsers/VttParser.cs
+++ b/SubtitlesParserV2/Formats/Parsers/VttParser.cs
@@ -49,14 +49,14 @@ namespace SubtitlesParserV2.Formats.Parsers
 		public List<SubtitleModel> ParseStream(Stream vttStream, Encoding encoding)
 		{
 			var ret = ParseStreamConsuming(vttStream, encoding).ToList();
-			if (ret.Count == 0) throw new ArgumentException(BadFormatMsg);
+			if (ret.Count == 0) throw new FormatException(BadFormatMsg);
 			return ret;
 		}
 
 		public async Task<List<SubtitleModel>> ParseStreamAsync(Stream stream, Encoding encoding, CancellationToken cancellationToken)
 		{
 			var ret = await ParseStreamConsumingAsync(stream, encoding, cancellationToken).ToListAsync(cancellationToken);
-			if (ret.Count == 0) throw new ArgumentException(BadFormatMsg);
+			if (ret.Count == 0) throw new FormatException(BadFormatMsg);
 			return ret;
 		}
 
@@ -68,7 +68,7 @@ namespace SubtitlesParserV2.Formats.Parsers
 
 			IEnumerable<string> parts = GetParts(vttStream, encoding).Peekable(out var partsAny);
 			if (!partsAny)
-				throw new ArgumentException(BadFormatMsg);
+				throw new FormatException(BadFormatMsg);
 
 			bool first = true;
 			foreach (string part in parts)
@@ -87,7 +87,7 @@ namespace SubtitlesParserV2.Formats.Parsers
 			var parts = GetPartsAsync(vttStream, encoding, cancellationToken);
 			var partsAny = await parts.PeekableAsync();
 			if (!partsAny)
-				throw new ArgumentException(BadFormatMsg);
+				throw new FormatException(BadFormatMsg);
 
 			bool first = true;
 			await foreach (string part in parts.WithCancellation(cancellationToken))

--- a/SubtitlesParserV2/Formats/Parsers/YttXmlParser.cs
+++ b/SubtitlesParserV2/Formats/Parsers/YttXmlParser.cs
@@ -1,10 +1,13 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Globalization;
 using System.IO;
 using System.Linq;
 using System.Net;
+using System.Runtime.CompilerServices;
 using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
 using System.Xml;
 using SubtitlesParserV2.Helpers;
 using SubtitlesParserV2.Models;
@@ -17,71 +20,200 @@ namespace SubtitlesParserV2.Formats.Parsers
 	/// <!--
 	/// Sources (Unofficial) : https://github.com/FyraLabs/yttml/blob/main/crates/srv3-ttml/internals/srv3-format.md
 	/// -->
-	internal class YttXmlParser : ISubtitlesParser
+	internal class YttXmlParser : ISubtitlesParser<YttXmlSubtitlePart>
 	{
+		private const string BadFormatMsg = "Stream is not in a valid Youtube XML format";
+
 		public List<SubtitleModel> ParseStream(Stream xmlStream, Encoding encoding)
+		{
+			var ret = ParseAsEnumerable(xmlStream, encoding).ToList();
+			if (ret.Count == 0) throw new ArgumentException(BadFormatMsg);
+			return ret;
+		}
+
+		public async Task<List<SubtitleModel>> ParseStreamAsync(Stream stream, Encoding encoding, CancellationToken cancellationToken)
+		{
+			var ret = await ParseAsEnumerableAsync(stream, encoding, cancellationToken).ToListAsync(cancellationToken);
+			if (ret.Count == 0) throw new ArgumentException(BadFormatMsg);
+			return ret;
+		}
+
+		public IEnumerable<SubtitleModel> ParseAsEnumerable(Stream xmlStream, Encoding encoding)
 		{
 			StreamHelper.ThrowIfStreamIsNotSeekableOrReadable(xmlStream);
 			// seek the beginning of the stream
 			xmlStream.Position = 0;
 
-			List<SubtitleModel> items = new List<SubtitleModel>();
-			// Read the xml stream line by line
 			using XmlReader reader = XmlReader.Create(xmlStream, new XmlReaderSettings() { IgnoreWhitespace = true, IgnoreComments = true });
+			IEnumerable<YttXmlSubtitlePart> parts = GetParts(reader).Peekable(out var partsAny);
+			if (!partsAny)
+				throw new ArgumentException(BadFormatMsg);
 
-			while (reader.Read()) 
+			bool first = true;
+			foreach (YttXmlSubtitlePart part in parts)
+			{
+				yield return ParsePart(part, first);
+				first = false;
+			}
+		}
+
+		public async IAsyncEnumerable<SubtitleModel> ParseAsEnumerableAsync(Stream xmlStream, Encoding encoding, [EnumeratorCancellation] CancellationToken cancellationToken)
+		{
+			StreamHelper.ThrowIfStreamIsNotSeekableOrReadable(xmlStream);
+			// seek the beginning of the stream
+			xmlStream.Position = 0;
+
+			using XmlReader reader = XmlReader.Create(xmlStream, new XmlReaderSettings() { IgnoreWhitespace = true, IgnoreComments = true, Async = true });
+			var parts = GetPartsAsync(reader, cancellationToken);
+			var partsAny = await parts.PeekableAsync();
+			if (!partsAny)
+				throw new ArgumentException(BadFormatMsg);
+
+			bool first = true;
+			await foreach (YttXmlSubtitlePart part in parts.WithCancellation(cancellationToken))
+			{
+				yield return ParsePart(part, first);
+				first = false;
+			}
+		}
+
+		public IEnumerable<YttXmlSubtitlePart> GetParts(TextReader reader)
+		{
+			// For YTT XML, we need to use XmlReader, not TextReader
+			// This method signature is required by the interface but not ideal for XML parsing
+			// We'll create the XmlReader from the TextReader
+			using XmlReader xmlReader = XmlReader.Create(reader, new XmlReaderSettings() { IgnoreWhitespace = true, IgnoreComments = true });
+			foreach (var part in GetPartsFromXmlReader(xmlReader))
+			{
+				yield return part;
+			}
+		}
+
+		public async IAsyncEnumerable<YttXmlSubtitlePart> GetPartsAsync(TextReader reader, [EnumeratorCancellation] CancellationToken cancellationToken = default)
+		{
+			// For YTT XML, we need to use XmlReader, not TextReader
+			using XmlReader xmlReader = XmlReader.Create(reader, new XmlReaderSettings() { IgnoreWhitespace = true, IgnoreComments = true, Async = true });
+			await foreach (var part in GetPartsFromXmlReaderAsync(xmlReader, cancellationToken))
+			{
+				yield return part;
+			}
+		}
+
+		private IEnumerable<YttXmlSubtitlePart> GetPartsFromXmlReader(XmlReader reader)
+		{
+			while (reader.Read())
 			{
 				// Search for subtitle elements (p for SRV3 and text for SRV1/SRV2)
 				if (reader.NodeType == XmlNodeType.Element && (reader.Name == "p" || reader.Name == "text"))
 				{
-					float start;
-					float duration = 0; // Default duration if parsing fails.
-
-					// Try to get the start & end time for SRV3 & SRV2 format (already in MS)
 					string startString = reader.GetAttribute("t") ?? string.Empty;
 					string durString = reader.GetAttribute("d") ?? string.Empty;
-					// Fallback to SRV1 format if parsing fail (In seconds)
-					if (!float.TryParse(startString, NumberStyles.Float, CultureInfo.InvariantCulture, out start) && !float.TryParse(durString, NumberStyles.Float, CultureInfo.InvariantCulture, out duration))
-					{
-						startString = reader.GetAttribute("start") ?? string.Empty;
-						durString = reader.GetAttribute("dur") ?? string.Empty;
-						if (float.TryParse(startString, NumberStyles.Float, CultureInfo.InvariantCulture, out start)) 
-						{
-							start = start * 1000; // Convert S to MS
-						} else start = -1; // Could not find start time, default "invalid" value is -1
-
-						if (float.TryParse(durString, NumberStyles.Float, CultureInfo.InvariantCulture, out duration)) 
-						{
-							duration = duration * 1000; // Convert duration S to MS.
-						}
-					}
+					string startStringSrv1 = reader.GetAttribute("start") ?? string.Empty;
+					string durStringSrv1 = reader.GetAttribute("dur") ?? string.Empty;
 
 					List<string> textLines = ParserHelper.XmlReadCurrentElementInnerText(reader);
-					if (textLines.Count >= 1)
-					{
-						// Get the text and html decode it as some versions (SRV1 & SRV2) uses html encoding
-						// for certains characters ( ' > &#39;t).
-						// NOTE: We does this on all lines
-						textLines = textLines.Select(line => WebUtility.HtmlDecode(line)).ToList();
 
-						items.Add(new SubtitleModel()
-						{
-							StartTime = (int)start,
-							EndTime = (int)(start + duration), // Calculate the "end" time with the duration of the subtitle.
-							Lines = textLines
-						});
-					}
+					yield return new YttXmlSubtitlePart
+					{
+						StartAttribute = startString,
+						DurationAttribute = durString,
+						StartAttributeSrv1 = startStringSrv1,
+						DurationAttributeSrv1 = durStringSrv1,
+						TextLines = textLines
+					};
+				}
+			}
+		}
+
+		private async IAsyncEnumerable<YttXmlSubtitlePart> GetPartsFromXmlReaderAsync(XmlReader reader, [EnumeratorCancellation] CancellationToken cancellationToken = default)
+		{
+			while (await reader.ReadAsync())
+			{
+				cancellationToken.ThrowIfCancellationRequested();
+
+				// Search for subtitle elements (p for SRV3 and text for SRV1/SRV2)
+				if (reader.NodeType == XmlNodeType.Element && (reader.Name == "p" || reader.Name == "text"))
+				{
+					string startString = reader.GetAttribute("t") ?? string.Empty;
+					string durString = reader.GetAttribute("d") ?? string.Empty;
+					string startStringSrv1 = reader.GetAttribute("start") ?? string.Empty;
+					string durStringSrv1 = reader.GetAttribute("dur") ?? string.Empty;
+
+					List<string> textLines = ParserHelper.XmlReadCurrentElementInnerText(reader);
+
+					yield return new YttXmlSubtitlePart
+					{
+						StartAttribute = startString,
+						DurationAttribute = durString,
+						StartAttributeSrv1 = startStringSrv1,
+						DurationAttributeSrv1 = durStringSrv1,
+						TextLines = textLines
+					};
+				}
+			}
+		}
+
+		public SubtitleModel ParsePart(YttXmlSubtitlePart part, bool isFirstPart)
+		{
+			float start;
+			float duration = 0; // Default duration if parsing fails.
+
+			// Try to get the start & end time for SRV3 & SRV2 format (already in MS)
+			string startString = part.StartAttribute;
+			string durString = part.DurationAttribute;
+
+			// Fallback to SRV1 format if parsing fail (In seconds)
+			if (!float.TryParse(startString, NumberStyles.Float, CultureInfo.InvariantCulture, out start) && !float.TryParse(durString, NumberStyles.Float, CultureInfo.InvariantCulture, out duration))
+			{
+				startString = part.StartAttributeSrv1;
+				durString = part.DurationAttributeSrv1;
+				if (float.TryParse(startString, NumberStyles.Float, CultureInfo.InvariantCulture, out start))
+				{
+					start = start * 1000; // Convert S to MS
+				}
+				else start = -1; // Could not find start time, default "invalid" value is -1
+
+				if (float.TryParse(durString, NumberStyles.Float, CultureInfo.InvariantCulture, out duration))
+				{
+					duration = duration * 1000; // Convert duration S to MS.
 				}
 			}
 
-			if (items.Count >= 1)
+			List<string> textLines = part.TextLines;
+			if (textLines.Count >= 1)
 			{
-				return items;
+				// Get the text and html decode it as some versions (SRV1 & SRV2) uses html encoding
+				// for certains characters ( ' > &#39;t).
+				// NOTE: We does this on all lines
+				textLines = textLines.Select(line => WebUtility.HtmlDecode(line)).ToList();
+
+				return new SubtitleModel()
+				{
+					StartTime = (int)start,
+					EndTime = (int)(start + duration), // Calculate the "end" time with the duration of the subtitle.
+					Lines = textLines
+				};
 			}
-			else
+
+			// Return an empty subtitle if no text lines
+			return new SubtitleModel()
 			{
-				throw new ArgumentException("Stream is not in a valid Youtube XML format");
-			}
+				StartTime = (int)start,
+				EndTime = (int)(start + duration),
+				Lines = new List<string>()
+			};
 		}
+	}
+
+	/// <summary>
+	/// Represents a parsed YTT XML subtitle part before conversion to SubtitleModel
+	/// </summary>
+	internal class YttXmlSubtitlePart
+	{
+		public string StartAttribute { get; set; } = string.Empty;
+		public string DurationAttribute { get; set; } = string.Empty;
+		public string StartAttributeSrv1 { get; set; } = string.Empty;
+		public string DurationAttributeSrv1 { get; set; } = string.Empty;
+		public List<string> TextLines { get; set; } = new List<string>();
 	}
 }

--- a/SubtitlesParserV2/Formats/Parsers/YttXmlParser.cs
+++ b/SubtitlesParserV2/Formats/Parsers/YttXmlParser.cs
@@ -26,19 +26,19 @@ namespace SubtitlesParserV2.Formats.Parsers
 
 		public List<SubtitleModel> ParseStream(Stream xmlStream, Encoding encoding)
 		{
-			var ret = ParseAsEnumerable(xmlStream, encoding).ToList();
+			var ret = ParseStreamConsuming(xmlStream, encoding).ToList();
 			if (ret.Count == 0) throw new ArgumentException(BadFormatMsg);
 			return ret;
 		}
 
 		public async Task<List<SubtitleModel>> ParseStreamAsync(Stream stream, Encoding encoding, CancellationToken cancellationToken)
 		{
-			var ret = await ParseAsEnumerableAsync(stream, encoding, cancellationToken).ToListAsync(cancellationToken);
+			var ret = await ParseStreamConsumingAsync(stream, encoding, cancellationToken).ToListAsync(cancellationToken);
 			if (ret.Count == 0) throw new ArgumentException(BadFormatMsg);
 			return ret;
 		}
 
-		public IEnumerable<SubtitleModel> ParseAsEnumerable(Stream xmlStream, Encoding encoding)
+		public IEnumerable<SubtitleModel> ParseStreamConsuming(Stream xmlStream, Encoding encoding)
 		{
 			StreamHelper.ThrowIfStreamIsNotSeekableOrReadable(xmlStream);
 			// seek the beginning of the stream
@@ -56,7 +56,7 @@ namespace SubtitlesParserV2.Formats.Parsers
 			}
 		}
 
-		public async IAsyncEnumerable<SubtitleModel> ParseAsEnumerableAsync(Stream xmlStream, Encoding encoding, [EnumeratorCancellation] CancellationToken cancellationToken)
+		public async IAsyncEnumerable<SubtitleModel> ParseStreamConsumingAsync(Stream xmlStream, Encoding encoding, [EnumeratorCancellation] CancellationToken cancellationToken)
 		{
 			StreamHelper.ThrowIfStreamIsNotSeekableOrReadable(xmlStream);
 			// seek the beginning of the stream

--- a/SubtitlesParserV2/Formats/Parsers/YttXmlParser.cs
+++ b/SubtitlesParserV2/Formats/Parsers/YttXmlParser.cs
@@ -27,14 +27,14 @@ namespace SubtitlesParserV2.Formats.Parsers
 		public List<SubtitleModel> ParseStream(Stream xmlStream, Encoding encoding)
 		{
 			var ret = ParseStreamConsuming(xmlStream, encoding).ToList();
-			if (ret.Count == 0) throw new ArgumentException(BadFormatMsg);
+			if (ret.Count == 0) throw new FormatException(BadFormatMsg);
 			return ret;
 		}
 
 		public async Task<List<SubtitleModel>> ParseStreamAsync(Stream stream, Encoding encoding, CancellationToken cancellationToken)
 		{
 			var ret = await ParseStreamConsumingAsync(stream, encoding, cancellationToken).ToListAsync(cancellationToken);
-			if (ret.Count == 0) throw new ArgumentException(BadFormatMsg);
+			if (ret.Count == 0) throw new FormatException(BadFormatMsg);
 			return ret;
 		}
 
@@ -46,7 +46,7 @@ namespace SubtitlesParserV2.Formats.Parsers
 
 			IEnumerable<YttXmlSubtitlePart> parts = GetParts(xmlStream, encoding).Peekable(out var partsAny);
 			if (!partsAny)
-				throw new ArgumentException(BadFormatMsg);
+				throw new FormatException(BadFormatMsg);
 
 			bool first = true;
 			foreach (YttXmlSubtitlePart part in parts)
@@ -65,7 +65,7 @@ namespace SubtitlesParserV2.Formats.Parsers
 			var parts = GetPartsAsync(xmlStream, encoding, cancellationToken);
 			var partsAny = await parts.PeekableAsync();
 			if (!partsAny)
-				throw new ArgumentException(BadFormatMsg);
+				throw new FormatException(BadFormatMsg);
 
 			bool first = true;
 			await foreach (YttXmlSubtitlePart part in parts.WithCancellation(cancellationToken))

--- a/SubtitlesParserV2/Formats/Parsers/YttXmlParser.cs
+++ b/SubtitlesParserV2/Formats/Parsers/YttXmlParser.cs
@@ -44,8 +44,7 @@ namespace SubtitlesParserV2.Formats.Parsers
 			// seek the beginning of the stream
 			xmlStream.Position = 0;
 
-			using XmlReader reader = XmlReader.Create(xmlStream, new XmlReaderSettings() { IgnoreWhitespace = true, IgnoreComments = true });
-			IEnumerable<YttXmlSubtitlePart> parts = GetParts(reader).Peekable(out var partsAny);
+			IEnumerable<YttXmlSubtitlePart> parts = GetParts(xmlStream, encoding).Peekable(out var partsAny);
 			if (!partsAny)
 				throw new ArgumentException(BadFormatMsg);
 
@@ -63,8 +62,7 @@ namespace SubtitlesParserV2.Formats.Parsers
 			// seek the beginning of the stream
 			xmlStream.Position = 0;
 
-			using XmlReader reader = XmlReader.Create(xmlStream, new XmlReaderSettings() { IgnoreWhitespace = true, IgnoreComments = true, Async = true });
-			var parts = GetPartsAsync(reader, cancellationToken);
+			var parts = GetPartsAsync(xmlStream, encoding, cancellationToken);
 			var partsAny = await parts.PeekableAsync();
 			if (!partsAny)
 				throw new ArgumentException(BadFormatMsg);
@@ -77,22 +75,18 @@ namespace SubtitlesParserV2.Formats.Parsers
 			}
 		}
 
-		public IEnumerable<YttXmlSubtitlePart> GetParts(TextReader reader)
+		public IEnumerable<YttXmlSubtitlePart> GetParts(Stream stream, Encoding encoding)
 		{
-			// For YTT XML, we need to use XmlReader, not TextReader
-			// This method signature is required by the interface but not ideal for XML parsing
-			// We'll create the XmlReader from the TextReader
-			using XmlReader xmlReader = XmlReader.Create(reader, new XmlReaderSettings() { IgnoreWhitespace = true, IgnoreComments = true });
+			using XmlReader xmlReader = XmlReader.Create(stream, new XmlReaderSettings() { IgnoreWhitespace = true, IgnoreComments = true });
 			foreach (var part in GetPartsFromXmlReader(xmlReader))
 			{
 				yield return part;
 			}
 		}
 
-		public async IAsyncEnumerable<YttXmlSubtitlePart> GetPartsAsync(TextReader reader, [EnumeratorCancellation] CancellationToken cancellationToken = default)
+		public async IAsyncEnumerable<YttXmlSubtitlePart> GetPartsAsync(Stream stream, Encoding encoding, [EnumeratorCancellation] CancellationToken cancellationToken = default)
 		{
-			// For YTT XML, we need to use XmlReader, not TextReader
-			using XmlReader xmlReader = XmlReader.Create(reader, new XmlReaderSettings() { IgnoreWhitespace = true, IgnoreComments = true, Async = true });
+			using XmlReader xmlReader = XmlReader.Create(stream, new XmlReaderSettings() { IgnoreWhitespace = true, IgnoreComments = true, Async = true });
 			await foreach (var part in GetPartsFromXmlReaderAsync(xmlReader, cancellationToken))
 			{
 				yield return part;

--- a/SubtitlesParserV2/Formats/Parsers/YttXmlParser.cs
+++ b/SubtitlesParserV2/Formats/Parsers/YttXmlParser.cs
@@ -62,8 +62,8 @@ namespace SubtitlesParserV2.Formats.Parsers
 			// seek the beginning of the stream
 			xmlStream.Position = 0;
 
-			var parts = GetPartsAsync(xmlStream, encoding, cancellationToken);
-			var partsAny = await parts.PeekableAsync();
+			var partsOld = GetPartsAsync(xmlStream, encoding, cancellationToken);
+			var (parts, partsAny) = await partsOld.PeekableAsync();
 			if (!partsAny)
 				throw new FormatException(BadFormatMsg);
 

--- a/SubtitlesParserV2/Helpers/EnumerableHelper.cs
+++ b/SubtitlesParserV2/Helpers/EnumerableHelper.cs
@@ -1,4 +1,6 @@
 ﻿using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
 
 namespace SubtitlesParserV2.Helpers
 {
@@ -16,9 +18,9 @@ namespace SubtitlesParserV2.Helpers
 			IEnumerator<T> enumerator = source.GetEnumerator();
 			// Try to iterate over the first element
 			hasElements = enumerator.MoveNext();
-			// Return our Enumerator implementation 
+			// Return our Enumerator implementation
 			return Impl(enumerator, hasElements);
-
+			// redundant
 			// Handle returning the first iterated element and iterating the next elements of the collection
 			// Need to be a local method as our parent method have a OUT argument, which is not compatible with yield returns
 			static IEnumerable<T> Impl(IEnumerator<T> enumerator, bool hasElements)
@@ -37,6 +39,25 @@ namespace SubtitlesParserV2.Helpers
 					}
 				}
 			}
+		}
+		public static async ValueTask<bool> PeekableAsync<T>(this IAsyncEnumerable<T> source)
+		{
+			IAsyncEnumerator<T> enumerator = source.GetAsyncEnumerator();
+			// Try to iterate over the first element
+			var hasElements =await enumerator.MoveNextAsync();
+			await enumerator.DisposeAsync();
+			// Return our Enumerator implementation
+			return hasElements;
+		}
+
+		public static async ValueTask<List<T>> ToListAsync<T>(this IAsyncEnumerable<T> source, CancellationToken cancellationToken = default)
+		{
+			List<T> ret = new List<T>();
+			await foreach (var item in source.WithCancellation(cancellationToken))
+			{
+				ret.Add(item);
+			}
+			return ret;
 		}
 	}
 }

--- a/SubtitlesParserV2/Models/SubtitleModel.cs
+++ b/SubtitlesParserV2/Models/SubtitleModel.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Linq;
 
 namespace SubtitlesParserV2.Models
 {
@@ -43,9 +44,14 @@ namespace SubtitlesParserV2.Models
             Lines = new List<string>();
         }
 
+        public override bool Equals(object? obj)
+        {
+	        return ReferenceEquals(this, obj) ||
+	               obj is SubtitleModel sm &&
+	               sm.EndTime == EndTime && sm.StartTime == StartTime && sm.Lines.SequenceEqual(Lines);
+        }
 
-
-		// Methods --------------------------------------------------------------------------
+        // Methods --------------------------------------------------------------------------
 		// Show the subtitle values
 		/// <inheritdoc/>
 		public override string ToString()
@@ -55,5 +61,6 @@ namespace SubtitlesParserV2.Models
             return string.Format("{0} --> {1}: {2}", startTime.ToString("G"), endTime.ToString("G"), string.Join(Environment.NewLine, Lines));
         }
 
+        internal static SubtitleModel Default { get; } = new SubtitleModel();
     }
 }

--- a/SubtitlesParserV2/SubtitleParser.cs
+++ b/SubtitlesParserV2/SubtitleParser.cs
@@ -303,7 +303,7 @@ namespace SubtitlesParserV2
 		{
 			if (!stream.CanRead)
 			{
-				throw new FormatException("Cannot parse a non-readable stream");
+				throw new ArgumentException("Cannot parse a non-readable stream");
 			}
 			Stream seekableStream = stream;
 			wasStreamCopied = false;

--- a/SubtitlesParserV2/SubtitleParser.cs
+++ b/SubtitlesParserV2/SubtitleParser.cs
@@ -7,6 +7,8 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
 
 namespace SubtitlesParserV2
 {
@@ -24,7 +26,7 @@ namespace SubtitlesParserV2
 		/// </summary>
 		/// <remarks>
 		/// All parsers will use the default configuration (of type <see cref="ISubtitlesParser"/>), some parsers also allow
-		/// you, when you use their instance directly, to use the type <see cref="ISubtitlesParser{TConfig}"/> and have your own
+		/// you, when you use their instance directly, to use the type <see cref="ISubtitlesParserWithConfig{TConfig}"/> and have your own
 		/// configuration. You can get a specific instance by using <see cref="SubtitleFormat.GetFormat(SubtitleFormatType)"/>.
 		/// </remarks>
 		/// <param name="stream">The subtitle stream</param>
@@ -41,18 +43,17 @@ namespace SubtitlesParserV2
 		/// </summary>
 		/// <remarks>
 		/// All parsers will use the default configuration (of type <see cref="ISubtitlesParser"/>), some parsers also allow
-		/// you, when you use their instance directly, to use the type <see cref="ISubtitlesParser{TConfig}"/> and have your own
+		/// you, when you use their instance directly, to use the type <see cref="ISubtitlesParserWithConfig{TConfig}"/> and have your own
 		/// configuration. You can get a specific instance by using <see cref="SubtitleFormat.GetFormat(SubtitleFormatType)"/>.
 		/// </remarks>
 		/// <param name="stream">The stream</param>
 		/// <param name="encoding">The encoding</param>
 		/// <param name="selectedFormat">If specified, will only try the selected parsers.</param>
-		/// <param name="ignoreException">If true (default), will ignore parsers exceptions and continue to the next one. If false, exception will be thrown,</param>
 		/// <returns>The corresponding list of SubtitleItem, null if parsing failed</returns>
 		/// <exception cref="ArgumentException"></exception>
-		public static SubtitleParserResultModel? ParseStream(Stream stream, Encoding encoding, SubtitleFormatType selectedFormat, bool? ignoreException = true)
+		public static SubtitleParserResultModel? ParseStream(Stream stream, Encoding encoding, SubtitleFormatType selectedFormat)
 		{
-			return ParseStream(stream, encoding, new SubtitleFormatType[] { selectedFormat }, ignoreException ?? true);
+			return ParseStream(stream, encoding, new SubtitleFormatType[] { selectedFormat });
 		}
 
 		/// <summary>
@@ -60,42 +61,23 @@ namespace SubtitlesParserV2
 		/// </summary>
 		/// <remarks>
 		/// All parsers will use the default configuration (of type <see cref="ISubtitlesParser"/>), some parsers also allow
-		/// you, when you use their instance directly, to use the type <see cref="ISubtitlesParser{TConfig}"/> and have your own
+		/// you, when you use their instance directly, to use the type <see cref="ISubtitlesParserWithConfig{TConfig}"/> and have your own
 		/// configuration. You can get a specific instance by using <see cref="SubtitleFormat.GetFormat(SubtitleFormatType)"/>.
 		/// </remarks>
 		/// <param name="stream">The stream</param>
 		/// <param name="encoding">The encoding</param>
 		/// <param name="selectedFormats">If specified, will only try the selected parsers.</param>
-		/// <param name="ignoreException">If true (default), will ignore parsers exceptions and continue to the next one. If false, exception will be thrown.</param>
 		/// <returns>The corresponding list of SubtitleItem, null if parsing failed</returns>
 		/// <exception cref="ArgumentException"></exception>
-		public static SubtitleParserResultModel? ParseStream(Stream stream, Encoding encoding, IEnumerable<SubtitleFormatType>? selectedFormats = null, bool ignoreException = true)
+		public static SubtitleParserResultModel? ParseStream(Stream stream, Encoding encoding, IEnumerable<SubtitleFormatType>? selectedFormats = null)
 		{
 			// test if stream if readable
-			if (!stream.CanRead)
-			{
-				throw new ArgumentException("Cannot parse a non-readable stream");
-			}
+			var seekableStream = PrepareStream(stream, out var wasStreamCopied);
 
-			Stream seekableStream = stream;
-			bool wasStreamCopied = false;
-			if (!stream.CanSeek) // Copy the stream if not seekable
-			{
-				seekableStream = StreamHelper.CopyStream(stream);
-				seekableStream.Seek(0, SeekOrigin.Begin);
-				wasStreamCopied = true;
-			}
-
-			// By default, we run all of the available formats
-			IEnumerable<SubtitleFormat> SubtitleFormatToRun;
-			// If a specific format was specified, we only use the specified format
-			if (selectedFormats != null)
-			{
-				SubtitleFormatToRun = SubtitleFormat.GetFormat(selectedFormats);
-			}
-			else SubtitleFormatToRun = SubtitleFormat.AllFormats; // Set all available formats
-
-			foreach (SubtitleFormat subtitleFormat in SubtitleFormatToRun)
+			IEnumerable<SubtitleFormat> subtitleFormatToRun = GetFormatsToRun(selectedFormats);
+			//replace ignoreException with delayed throwing.
+			Exception lastException = null;
+			foreach (SubtitleFormat subtitleFormat in subtitleFormatToRun)
 			{
 				try
 				{
@@ -110,9 +92,9 @@ namespace SubtitlesParserV2
 					}
 					return new SubtitleParserResultModel(subtitleFormat.FormatType,items); // end method execution
 				}
-				catch when (ignoreException) // If ignoreException is true, we ignore it and try the next parser
+				catch (Exception e) // If ignoreException is true, we ignore it and try the next parser
 				{
-					continue; // Let's try the next parser...
+					lastException = e;
 				}
 			}
 
@@ -122,7 +104,217 @@ namespace SubtitlesParserV2
 				// Ensure the stream copy is disposed
 				seekableStream?.Dispose();
 			}
-			return null;
+			throw lastException;
+		}
+
+
+
+		/// <summary>
+		/// Try each subtitle format to parse the subtitle, read the stream with UTF-8 decoding.
+		/// </summary>
+		/// <param name="stream">Subtitle content to parse</param>
+		/// <param name="cancellationToken">Cancellation token to cancel the operation.</param>
+		/// <returns>Parsed model, or <code>null</code> if the <code>ignoreException</code> parameter was <code>true</code></returns>
+		/// <exception cref="ArgumentException">Stream cannot be read</exception>
+		/// <exception cref="FormatException">Subtitle content is in invalid format.</exception>
+		public static Task<SubtitleParserResultModel> ParseStreamAsync(Stream stream, CancellationToken cancellationToken = default) =>
+			ParseStreamAsync(stream, Encoding.UTF8, cancellationToken: cancellationToken);
+
+		/// <summary>
+		/// Parse the subtitle with the <code>encoding</code> and <code>selectedFormat</code>.
+		/// </summary>
+		/// <param name="stream">Subtitle content to parse</param>
+		/// <param name="encoding">encoding to read the <code>stream</code></param>
+		/// <param name="selectedFormat">format to parse</param>
+		/// <param name="cancellationToken">Cancellation token to cancel the operation.</param>
+		/// <returns>Parsed model, or <code>null</code> if the <code>ignoreException</code> parameter was <code>true</code></returns>
+		/// <exception cref="ArgumentException">Stream cannot be read</exception>
+		/// <exception cref="FormatException">Subtitle content is in invalid format.</exception>
+		public static Task<SubtitleParserResultModel> ParseStreamAsync(Stream stream, Encoding encoding, SubtitleFormatType selectedFormat, CancellationToken cancellationToken = default) =>
+			ParseStreamAsync(stream, encoding, new[] { selectedFormat },  cancellationToken);
+
+		/// <summary>
+		/// Parse the subtitle content by trying each format, with the specified <code>encoding</code>.
+		/// </summary>
+		/// <param name="stream">Subtitle content to parse</param>
+		/// <param name="encoding">encoding to read the <code>stream</code></param>
+		/// <param name="selectedFormats">formats to parse</param>
+		/// <param name="cancellationToken">Cancellation token to cancel the operation.</param>
+		/// <returns>Parsed model, or <code>null</code> if the <code>ignoreException</code> parameter was <code>true</code></returns>
+		/// <exception cref="ArgumentException">Stream cannot be read</exception>
+		/// <exception cref="FormatException">Subtitle content is in invalid format.</exception>
+		public static async Task<SubtitleParserResultModel> ParseStreamAsync(Stream stream, Encoding encoding, IEnumerable<SubtitleFormatType>? selectedFormats = null, CancellationToken cancellationToken = default)
+		{
+			// test if stream if readable
+			var seekableStream = PrepareStream(stream, out var wasStreamCopied);
+
+			// By default, we run all of the available formats
+			IEnumerable<SubtitleFormat> subtitleFormatToRun = GetFormatsToRun(selectedFormats);
+			Exception lastException = null;
+			foreach (SubtitleFormat subtitleFormat in subtitleFormatToRun)
+			{
+				try
+				{
+					ISubtitlesParser parser = subtitleFormat.ParserInstance;
+					_logger.LogDebug("Parsing with : {name}", Enum.GetName(typeof(SubtitleFormatType), subtitleFormat.FormatType));
+					List<SubtitleModel> items = await parser.ParseStreamAsync(seekableStream, encoding, cancellationToken);
+					// Pass this point, if a error wasn't thrown, the right parser was used
+					if (wasStreamCopied)
+					{
+						// Ensure the stream copy is disposed
+						await seekableStream.DisposeAsync();
+					}
+					return new SubtitleParserResultModel(subtitleFormat.FormatType,items); // end method execution
+				}
+				catch (Exception e) // If ignoreException is true, we ignore it and try the next parser
+				{
+					lastException = e;
+				}
+			}
+
+			// We only reach this part of the code if all parsers failed
+			if (wasStreamCopied)
+			{
+				// Ensure the stream copy is disposed
+				await seekableStream.DisposeAsync();
+			}
+
+			throw lastException;
+		}
+		/// <summary>
+		/// Get a consuming parser from the subtitle content, to read and process the subtitle items in a single iteration. Use UTF-8 encoding and try to parse with all subtitle formats.
+		/// </summary>
+		/// <remarks>It is recommended to use the overload with <c>selectedFormats</c> parameter as this overload tries every format to parse with. You should not use the <c>stream</c> while this enumerable is being consumed.</remarks>
+		/// <param name="stream">Subtitle content</param>
+		/// <returns>Consuming enumerable to read subtitle items.</returns>
+		/// <exception cref="FormatException">Content cannot be parsed.</exception>
+		public static IEnumerable<SubtitleModel> GetConsumingParser(Stream stream) =>
+			GetConsumingParser(stream, Encoding.UTF8);
+		/// <summary>
+		/// Get a consuming parser from the subtitle content, to read and process the subtitle items in a single iteration. Use UTF-8 encoding and try to parse with all subtitle formats.
+		/// </summary>
+		/// <remarks>You should not use the <c>stream</c> while this enumerable is being consumed.</remarks>
+		/// <param name="stream">Subtitle content</param>
+		/// <param name="encoding">Encoding to decode the <c>stream</c></param>
+		/// <param name="selectedFormats">Formats to parse with.</param>
+		/// <returns>Consuming enumerable to read subtitle items.</returns>
+		/// <exception cref="FormatException">Content cannot be parsed.</exception>
+		public static IEnumerable<SubtitleModel> GetConsumingParser(Stream stream, Encoding encoding,
+			IEnumerable<SubtitleFormatType>? selectedFormats = null)
+		{
+			stream = PrepareStream(stream, out bool streamCopied);
+			var formatsToRun = GetFormatsToRun(selectedFormats);
+			Exception lastException = null;
+			foreach (var subtitleFormat in formatsToRun)
+			{
+				try
+				{
+					ISubtitlesParser parser = subtitleFormat.ParserInstance;
+					_logger.LogDebug("Parsing with : {name}", Enum.GetName(typeof(SubtitleFormatType), subtitleFormat.FormatType));
+					var result = parser.ParseStreamConsuming(stream, encoding);
+					// Pass this point, if a error wasn't thrown, the right parser was used
+					if (streamCopied)
+					{
+						// Ensure the stream copy is disposed
+						stream.Dispose();
+					}
+					return result;
+				}
+				catch (Exception e)
+				{
+					lastException = e;
+				}
+			}
+
+			if (streamCopied)
+			{
+				stream.Dispose();
+			}
+			throw lastException;
+		}
+		/// <summary>
+		/// Get a asynchronous consuming parser from the subtitle content, to read and process the subtitle items in a single iteration asynchronously. Use UTF-8 encoding and try to parse with all subtitle formats.
+		/// </summary>
+		/// <remarks>It is recommended to use the overload with <c>selectedFormats</c> parameter as this overload tries every format to parse with. You should not use the <c>stream</c> while this enumerable is being consumed.</remarks>
+		/// <param name="stream">Subtitle content</param>
+		/// <param name="encoding">Encoding to decode the <c>stream</c></param>
+		/// <param name="selectedFormats">Formats to parse with.</param>
+		/// <param name="cancellationToken">Token to cancel the operation.</param>
+		/// <returns>Consuming enumerable to read subtitle items.</returns>
+		/// <exception cref="FormatException">Content cannot be parsed.</exception>
+		public static IAsyncEnumerable<SubtitleModel> GetAsyncConsumingParser(Stream stream, CancellationToken cancellationToken = default)=>
+		GetAsyncConsumingParser(stream, Encoding.UTF8, cancellationToken:cancellationToken);
+
+		/// <summary>
+		/// Get an asynchronous consuming parser from the subtitle content, to read and process the subtitle items in a single iteration asynchronously. Use UTF-8 encoding and try to parse with all subtitle formats.
+		/// </summary>
+		/// <remarks>You should not use the <c>stream</c> while this enumerable is being consumed.</remarks>
+		/// <param name="stream">Subtitle content</param>
+		/// <param name="encoding">Encoding to decode the <c>stream</c></param>
+		/// <param name="selectedFormats">Formats to parse with.</param>
+		/// <param name="cancellationToken">Token to cancel the operation.</param>
+		/// <returns>Consuming enumerable to read subtitle items.</returns>
+		/// <exception cref="FormatException">Content cannot be parsed.</exception>
+		public static IAsyncEnumerable<SubtitleModel> GetAsyncConsumingParser(Stream stream, Encoding encoding,
+			IEnumerable<SubtitleFormatType>? selectedFormats = null, CancellationToken cancellationToken = default)
+		{
+			stream =  PrepareStream(stream, out bool streamCopied);
+			var formatsToRun = GetFormatsToRun(selectedFormats);
+			Exception lastException = null;
+			foreach (var subtitleFormat in formatsToRun)
+			{
+				try
+				{
+					ISubtitlesParser parser = subtitleFormat.ParserInstance;
+					_logger.LogDebug("Parsing with : {name}", Enum.GetName(typeof(SubtitleFormatType), subtitleFormat.FormatType));
+					var result = parser.ParseStreamConsumingAsync(stream, encoding, cancellationToken);
+					// Pass this point, if a error wasn't thrown, the right parser was used
+
+					if (streamCopied)
+					{
+						// Ensure the stream copy is disposed
+						stream.Dispose();
+					}
+					return result;
+				}
+				catch (Exception e)
+				{
+					lastException = e;
+				}
+			}
+			if(streamCopied)
+				stream.Dispose();
+			throw lastException;
+		}
+		private static IEnumerable<SubtitleFormat> GetFormatsToRun(IEnumerable<SubtitleFormatType>? selectedFormats)
+		{
+			// By default, we run all of the available formats
+			IEnumerable<SubtitleFormat> SubtitleFormatToRun;
+			// If a specific format was specified, we only use the specified format
+			if (selectedFormats != null)
+			{
+				SubtitleFormatToRun = SubtitleFormat.GetFormat(selectedFormats);
+			}
+			else SubtitleFormatToRun = SubtitleFormat.AllFormats; // Set all available formats
+
+			return SubtitleFormatToRun;
+		}
+		private static Stream PrepareStream(Stream stream, out bool wasStreamCopied)
+		{
+			if (!stream.CanRead)
+			{
+				throw new ArgumentException("Cannot parse a non-readable stream");
+			}
+			Stream seekableStream = stream;
+			wasStreamCopied = false;
+			if (!stream.CanSeek) // Copy the stream if not seekable
+			{
+				seekableStream = StreamHelper.CopyStream(stream);
+				seekableStream.Seek(0, SeekOrigin.Begin);
+				wasStreamCopied = true;
+			}
+
+			return seekableStream;
 		}
 	}
 }

--- a/SubtitlesParserV2/SubtitleParser.cs
+++ b/SubtitlesParserV2/SubtitleParser.cs
@@ -303,7 +303,7 @@ namespace SubtitlesParserV2
 		{
 			if (!stream.CanRead)
 			{
-				throw new ArgumentException("Cannot parse a non-readable stream");
+				throw new FormatException("Cannot parse a non-readable stream");
 			}
 			Stream seekableStream = stream;
 			wasStreamCopied = false;

--- a/SubtitlesParserV2/SubtitlesParserV2.csproj
+++ b/SubtitlesParserV2/SubtitlesParserV2.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Library</OutputType>
-    <TargetFrameworks>net8.0;netstandard2.1</TargetFrameworks>
+    <TargetFrameworks>net8.0;netstandard2.1;net9.0</TargetFrameworks>
     <ApplicationIcon />
     <StartupObject />
     <PackageId>SubtitlesParserV2</PackageId>


### PR DESCRIPTION
### Summary
Purpose of this pull request is to add consuming processing / stream processing as well as Async overloads for new and existing methods. It extends ISubtitlesParser interface and standardizes pipeline steps across all parser types. It updates tests to test the async overloads as well and performs minor refactor on existing methods.

## Features
### Stream Processing
The whole pipeline is executed lazily, when the consuming enumerable is iterated. 
**Note** that iteration through 'formats to run' will not work like it does in the ParseStream method in enumerable methods because it would be a logical error if the enumerator just returned to the beginning of subtitle content with a different parser instead of throwing when an exception occured. Therefore, *retrying with different formats will happen only if the format incompatibilty is deteced in the first part of the subtitle content* (via Peekable).
### Async Overloads
Asynchronous overloads to existing and streaming methods. Note that synchronous methods are stil *true synchronous*, they are not blocking-waited asynchronous calls. So each parser method is basically written twice with sync and async method calls.

## Refactor
### Parsers
For streaming processing, i needed to decouple lexing the parts and parsing them in some parsers. I standardized this pattern across all parsers by extending the ISubtitleParser and refactoring the pipeline in each parser.
### Static Parser (SubtitleParser)
Removed the ignoreException parameter and introduced delayed rethrowing to ParseStream methods instead. This now both moves to the next parser when error occurs and propogates the *last* exception to the caller if no parser succeded.

### Tests
**Async methods:** Added testing assertions on results of async methods on existing test methods.
**Minor fix**: replaced Assert.Contains with Assert.All as it was the wrong assertion to use for the purpose.
*All tests in Test_Parsers pass*
*Test_Library program pass.* (reports -1 on the end time of last lines in lrc, smi and tmp because there is no end timestamp on these formats. Presumably main branch behaves the same.)

**Misc**
Added NET 9.0 to target frameworks.
Added docs for the new SubtitleParser static methods.